### PR TITLE
Add a generic XML adapter

### DIFF
--- a/generic-messages/src/main/java/com/langtoun/messages/generic/PayloadJsonDeserializer.java
+++ b/generic-messages/src/main/java/com/langtoun/messages/generic/PayloadJsonDeserializer.java
@@ -27,15 +27,15 @@ import com.langtoun.messages.types.properties.ScalarProperty;
  * interface.
  *
  */
-public class MessageJsonDeserializer extends JsonDeserializer<SerializablePayload> implements ContextualDeserializer {
+public class PayloadJsonDeserializer extends JsonDeserializer<SerializablePayload> implements ContextualDeserializer {
 
   private JavaType javaType;
 
-  public MessageJsonDeserializer() {
+  public PayloadJsonDeserializer() {
 
   }
 
-  public MessageJsonDeserializer(final JavaType javaType) {
+  public PayloadJsonDeserializer(final JavaType javaType) {
     this.javaType = javaType;
   }
 
@@ -56,7 +56,7 @@ public class MessageJsonDeserializer extends JsonDeserializer<SerializablePayloa
   public JsonDeserializer<?> createContextual(final DeserializationContext context, final BeanProperty property)
       throws JsonMappingException {
     final JavaType javaType = context.getContextualType() != null ? context.getContextualType() : property.getMember().getType();
-    return new MessageJsonDeserializer(javaType);
+    return new PayloadJsonDeserializer(javaType);
   }
 
   private static SerializablePayload deserializePayload(final SerializablePayload payload, final JsonNode root,

--- a/generic-messages/src/main/java/com/langtoun/messages/generic/PayloadJsonSerializer.java
+++ b/generic-messages/src/main/java/com/langtoun/messages/generic/PayloadJsonSerializer.java
@@ -18,7 +18,7 @@ import com.langtoun.messages.types.properties.ScalarProperty;
  * interface.
  *
  */
-public class MessageJsonSerializer extends JsonSerializer<SerializablePayload> {
+public class PayloadJsonSerializer extends JsonSerializer<SerializablePayload> {
 
   @Override
   public void serialize(final SerializablePayload value, final JsonGenerator gen, final SerializerProvider serializers)

--- a/generic-messages/src/main/java/com/langtoun/messages/generic/PayloadXmlAdapter.java
+++ b/generic-messages/src/main/java/com/langtoun/messages/generic/PayloadXmlAdapter.java
@@ -1,0 +1,21 @@
+package com.langtoun.messages.generic;
+
+import javax.xml.bind.annotation.adapters.XmlAdapter;
+
+import com.langtoun.messages.types.SerializablePayload;
+
+public class PayloadXmlAdapter extends XmlAdapter<String, SerializablePayload> {
+
+  @Override
+  public SerializablePayload unmarshal(String v) throws Exception {
+    // TODO Auto-generated method stub
+    return null;
+  }
+
+  @Override
+  public String marshal(SerializablePayload v) throws Exception {
+    // TODO Auto-generated method stub
+    return null;
+  }
+
+}

--- a/generic-messages/src/main/java/com/langtoun/messages/types/SerializablePayload.java
+++ b/generic-messages/src/main/java/com/langtoun/messages/types/SerializablePayload.java
@@ -4,16 +4,16 @@ import java.util.List;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.langtoun.messages.generic.MessageJsonDeserializer;
-import com.langtoun.messages.generic.MessageJsonSerializer;
+import com.langtoun.messages.generic.PayloadJsonDeserializer;
+import com.langtoun.messages.generic.PayloadJsonSerializer;
 import com.langtoun.messages.types.properties.MessageProperty;
 
 /**
  * Interface for payload types that are to be handled by generic serializers and
  * deserializers.
  */
-@JsonSerialize(using = MessageJsonSerializer.class)
-@JsonDeserialize(using = MessageJsonDeserializer.class)
+@JsonSerialize(using = PayloadJsonSerializer.class)
+@JsonDeserialize(using = PayloadJsonDeserializer.class)
 public interface SerializablePayload {
 
   /**

--- a/generic-messages/src/test/java/com/langtoun/messages/types/gen/cars/CarEngine.java
+++ b/generic-messages/src/test/java/com/langtoun/messages/types/gen/cars/CarEngine.java
@@ -8,8 +8,8 @@ import java.util.List;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.langtoun.messages.generic.MessageJsonDeserializer;
-import com.langtoun.messages.generic.MessageJsonSerializer;
+import com.langtoun.messages.generic.PayloadJsonDeserializer;
+import com.langtoun.messages.generic.PayloadJsonSerializer;
 import com.langtoun.messages.types.SerializablePayload;
 import com.langtoun.messages.types.properties.MessageProperty;
 
@@ -17,8 +17,8 @@ import com.langtoun.messages.types.properties.MessageProperty;
  * Surrogate for a generated type that implements {@link SerializablePayload}.
  *
  */
-@JsonSerialize(using = MessageJsonSerializer.class, as = CarEngine.class)
-@JsonDeserialize(using = MessageJsonDeserializer.class, as = CarEngine.class)
+@JsonSerialize(using = PayloadJsonSerializer.class, as = CarEngine.class)
+@JsonDeserialize(using = PayloadJsonDeserializer.class, as = CarEngine.class)
 public class CarEngine implements SerializablePayload {
 
   private Integer cylinders; // required

--- a/generic-messages/src/test/java/com/langtoun/messages/types/gen/cars/CarFeature.java
+++ b/generic-messages/src/test/java/com/langtoun/messages/types/gen/cars/CarFeature.java
@@ -8,8 +8,8 @@ import java.util.List;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.langtoun.messages.generic.MessageJsonDeserializer;
-import com.langtoun.messages.generic.MessageJsonSerializer;
+import com.langtoun.messages.generic.PayloadJsonDeserializer;
+import com.langtoun.messages.generic.PayloadJsonSerializer;
 import com.langtoun.messages.types.SerializablePayload;
 import com.langtoun.messages.types.properties.MessageProperty;
 
@@ -17,8 +17,8 @@ import com.langtoun.messages.types.properties.MessageProperty;
  * Surrogate for a generated type that implements {@link SerializablePayload}.
  *
  */
-@JsonSerialize(using = MessageJsonSerializer.class, as = CarFeature.class)
-@JsonDeserialize(using = MessageJsonDeserializer.class, as = CarFeature.class)
+@JsonSerialize(using = PayloadJsonSerializer.class, as = CarFeature.class)
+@JsonDeserialize(using = PayloadJsonDeserializer.class, as = CarFeature.class)
 public class CarFeature implements SerializablePayload {
 
   private String name;

--- a/generic-messages/src/test/java/com/langtoun/messages/types/gen/cars/ComplexCar.java
+++ b/generic-messages/src/test/java/com/langtoun/messages/types/gen/cars/ComplexCar.java
@@ -6,8 +6,8 @@ import java.util.List;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.langtoun.messages.generic.MessageJsonDeserializer;
-import com.langtoun.messages.generic.MessageJsonSerializer;
+import com.langtoun.messages.generic.PayloadJsonDeserializer;
+import com.langtoun.messages.generic.PayloadJsonSerializer;
 import com.langtoun.messages.types.SerializablePayload;
 import com.langtoun.messages.types.properties.MessageProperty;
 
@@ -15,8 +15,8 @@ import com.langtoun.messages.types.properties.MessageProperty;
  * Surrogate for a generated type that implements {@link SerializablePayload}.
  *
  */
-@JsonSerialize(using = MessageJsonSerializer.class, as = ComplexCar.class)
-@JsonDeserialize(using = MessageJsonDeserializer.class, as = ComplexCar.class)
+@JsonSerialize(using = PayloadJsonSerializer.class, as = ComplexCar.class)
+@JsonDeserialize(using = PayloadJsonDeserializer.class, as = ComplexCar.class)
 public class ComplexCar extends SimpleCar {
 
   private CarEngine engine; // required

--- a/generic-messages/src/test/java/com/langtoun/messages/types/gen/cars/ComplexCarWithFeatures.java
+++ b/generic-messages/src/test/java/com/langtoun/messages/types/gen/cars/ComplexCarWithFeatures.java
@@ -8,8 +8,8 @@ import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.langtoun.messages.generic.MessageJsonDeserializer;
-import com.langtoun.messages.generic.MessageJsonSerializer;
+import com.langtoun.messages.generic.PayloadJsonDeserializer;
+import com.langtoun.messages.generic.PayloadJsonSerializer;
 import com.langtoun.messages.types.SerializablePayload;
 import com.langtoun.messages.types.properties.MessageProperty;
 
@@ -17,8 +17,8 @@ import com.langtoun.messages.types.properties.MessageProperty;
  * Surrogate for a generated type that implements {@link SerializablePayload}.
  *
  */
-@JsonSerialize(using = MessageJsonSerializer.class, as = ComplexCarWithFeatures.class)
-@JsonDeserialize(using = MessageJsonDeserializer.class, as = ComplexCarWithFeatures.class)
+@JsonSerialize(using = PayloadJsonSerializer.class, as = ComplexCarWithFeatures.class)
+@JsonDeserialize(using = PayloadJsonDeserializer.class, as = ComplexCarWithFeatures.class)
 public class ComplexCarWithFeatures extends ComplexCar {
 
   private final List<CarFeature> features = new ArrayList<>();

--- a/generic-messages/src/test/java/com/langtoun/messages/types/gen/cars/SimpleCar.java
+++ b/generic-messages/src/test/java/com/langtoun/messages/types/gen/cars/SimpleCar.java
@@ -8,8 +8,8 @@ import java.util.List;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.langtoun.messages.generic.MessageJsonDeserializer;
-import com.langtoun.messages.generic.MessageJsonSerializer;
+import com.langtoun.messages.generic.PayloadJsonDeserializer;
+import com.langtoun.messages.generic.PayloadJsonSerializer;
 import com.langtoun.messages.types.SerializablePayload;
 import com.langtoun.messages.types.properties.MessageProperty;
 
@@ -17,8 +17,8 @@ import com.langtoun.messages.types.properties.MessageProperty;
  * Surrogate for a generated type that implements {@link SerializablePayload}.
  *
  */
-@JsonSerialize(using = MessageJsonSerializer.class, as = SimpleCar.class)
-@JsonDeserialize(using = MessageJsonDeserializer.class, as = SimpleCar.class)
+@JsonSerialize(using = PayloadJsonSerializer.class, as = SimpleCar.class)
+@JsonDeserialize(using = PayloadJsonDeserializer.class, as = SimpleCar.class)
 public class SimpleCar implements SerializablePayload {
 
   private String colour; // required


### PR DESCRIPTION
### Refactor JSON serializer / deserializer class names

The original idea was to have a Message object that contained a
serializable payload and the naming of classes reflects this. Now it's
time to remove Message from the class names so that we end up with:

  - PayloadJsonDeserializer
  - PayloadJsonSerializer