### PR TITLE
Add builders for list and scalar properties

### DIFF
--- a/generic-messages/src/main/java/com/langtoun/messages/generic/PayloadJsonDeserializer.java
+++ b/generic-messages/src/main/java/com/langtoun/messages/generic/PayloadJsonDeserializer.java
@@ -19,7 +19,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.ValueNode;
 import com.langtoun.messages.types.SerializablePayload;
 import com.langtoun.messages.types.properties.ListProperty;
-import com.langtoun.messages.types.properties.MessageProperty;
+import com.langtoun.messages.types.properties.PayloadProperty;
 import com.langtoun.messages.types.properties.ScalarProperty;
 
 /**
@@ -27,15 +27,15 @@ import com.langtoun.messages.types.properties.ScalarProperty;
  * interface.
  *
  */
-public class MessageJsonDeserializer extends JsonDeserializer<SerializablePayload> implements ContextualDeserializer {
+public class PayloadJsonDeserializer extends JsonDeserializer<SerializablePayload> implements ContextualDeserializer {
 
   private JavaType javaType;
 
-  public MessageJsonDeserializer() {
+  public PayloadJsonDeserializer() {
 
   }
 
-  public MessageJsonDeserializer(final JavaType javaType) {
+  public PayloadJsonDeserializer(final JavaType javaType) {
     this.javaType = javaType;
   }
 
@@ -56,12 +56,12 @@ public class MessageJsonDeserializer extends JsonDeserializer<SerializablePayloa
   public JsonDeserializer<?> createContextual(final DeserializationContext context, final BeanProperty property)
       throws JsonMappingException {
     final JavaType javaType = context.getContextualType() != null ? context.getContextualType() : property.getMember().getType();
-    return new MessageJsonDeserializer(javaType);
+    return new PayloadJsonDeserializer(javaType);
   }
 
   private static SerializablePayload deserializePayload(final SerializablePayload payload, final JsonNode root,
       final String nodePath, final String indent) {
-    for (final MessageProperty property : payload.getProperties()) {
+    for (final PayloadProperty property : payload.getProperties()) {
       // find each property in turn and populate the payload, creating new payload
       // objects as the deserializer walks the node tree
       final String fieldName = property.getJsonName();

--- a/generic-messages/src/main/java/com/langtoun/messages/generic/PayloadJsonSerializer.java
+++ b/generic-messages/src/main/java/com/langtoun/messages/generic/PayloadJsonSerializer.java
@@ -10,7 +10,7 @@ import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.langtoun.messages.types.SerializablePayload;
 import com.langtoun.messages.types.properties.ListProperty;
-import com.langtoun.messages.types.properties.MessageProperty;
+import com.langtoun.messages.types.properties.PayloadProperty;
 import com.langtoun.messages.types.properties.ScalarProperty;
 
 /**
@@ -18,7 +18,7 @@ import com.langtoun.messages.types.properties.ScalarProperty;
  * interface.
  *
  */
-public class MessageJsonSerializer extends JsonSerializer<SerializablePayload> {
+public class PayloadJsonSerializer extends JsonSerializer<SerializablePayload> {
 
   @Override
   public void serialize(final SerializablePayload value, final JsonGenerator gen, final SerializerProvider serializers)
@@ -30,7 +30,7 @@ public class MessageJsonSerializer extends JsonSerializer<SerializablePayload> {
       final SerializerProvider serializers) throws IOException {
     if (payload != null) {
       gen.writeStartObject();
-      for (final MessageProperty property : payload.getProperties()) {
+      for (final PayloadProperty property : payload.getProperties()) {
         if (property instanceof ListProperty) {
           final ListProperty listProperty = (ListProperty) property;
           writeArrayValues(listProperty.getJsonName(), listProperty.getGetter().get(), listProperty.isRequired(), gen, serializers);

--- a/generic-messages/src/main/java/com/langtoun/messages/types/SerializablePayload.java
+++ b/generic-messages/src/main/java/com/langtoun/messages/types/SerializablePayload.java
@@ -4,24 +4,24 @@ import java.util.List;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.langtoun.messages.generic.MessageJsonDeserializer;
-import com.langtoun.messages.generic.MessageJsonSerializer;
-import com.langtoun.messages.types.properties.MessageProperty;
+import com.langtoun.messages.generic.PayloadJsonDeserializer;
+import com.langtoun.messages.generic.PayloadJsonSerializer;
+import com.langtoun.messages.types.properties.PayloadProperty;
 
 /**
  * Interface for payload types that are to be handled by generic serializers and
  * deserializers.
  */
-@JsonSerialize(using = MessageJsonSerializer.class)
-@JsonDeserialize(using = MessageJsonDeserializer.class)
+@JsonSerialize(using = PayloadJsonSerializer.class)
+@JsonDeserialize(using = PayloadJsonDeserializer.class)
 public interface SerializablePayload {
 
   /**
    * Provide the configuration for the properties that are to be transported in
    * the generic message.
    *
-   * @return a list of {@link MessageProperty} objects
+   * @return a list of {@link PayloadProperty} objects
    */
-  List<MessageProperty> getProperties();
+  List<PayloadProperty> getProperties();
 
 }

--- a/generic-messages/src/main/java/com/langtoun/messages/types/properties/ListProperty.java
+++ b/generic-messages/src/main/java/com/langtoun/messages/types/properties/ListProperty.java
@@ -6,39 +6,61 @@ import java.util.function.Supplier;
 
 public class ListProperty extends PayloadProperty {
 
-  private final Supplier<List<Object>> getter;
-  private final Consumer<List<Object>> setter;
+  private Supplier<List<Object>> getter;
+  private Consumer<List<Object>> setter;
+  private Class<?> itemType;
 
-  private final Class<?> itemType;
-
-  protected ListProperty(final String name, final String jsonName, final String xmlName, final boolean required, final Supplier<List<Object>> getter,
-      final Consumer<List<Object>> setter, final Class<?> valueType, final Class<?> itemType) {
+  protected ListProperty(final String name, final String jsonName, final String xmlName, final boolean required,
+      final Class<?> valueType) {
     super(name, jsonName, xmlName, required, valueType);
-    this.getter = getter;
-    this.setter = setter;
-    this.itemType = itemType;
   }
 
-  public static ListProperty newListProperty(final String name, final String jsonName, final String xmlName, final boolean required,
-      final Supplier<List<Object>> getter, final Consumer<List<Object>> setter, final Class<?> valueType, final Class<?> itemType) {
-    return new ListProperty(name, jsonName, xmlName, required, getter, setter, valueType, itemType);
-  }
+  public Supplier<List<Object>> getGetter() { return getter; }
 
-  public Supplier<List<Object>> getGetter() {
-    return getter;
-  }
+  public Consumer<List<Object>> getSetter() { return setter; }
 
-  public Consumer<List<Object>> getSetter() {
-    return setter;
-  }
-
-  public Class<?> getItemType() {
-    return itemType;
-  }
+  public Class<?> getItemType() { return itemType; }
 
   @Override
   public String toString() {
     return "listProp[super=" + super.toString() + "], itemType=" + itemType.getTypeName() + "]";
+  }
+
+  public static class Builder {
+
+    private static ListProperty property;
+
+    private Builder(final String name, final String jsonName, final String xmlName, final boolean required) {
+      property = new ListProperty(name, jsonName, xmlName, required, List.class);
+    }
+
+    public static Builder newBuilder(final String name, final String jsonName, final String xmlName, final boolean required) {
+      return new Builder(name, jsonName, xmlName, required);
+    }
+
+    public Builder addGetter(Supplier<List<Object>> getter) {
+      property.getter = getter;
+      return this;
+    }
+
+    public Builder addSetter(Consumer<List<Object>> setter) {
+      property.setter = setter;
+      return this;
+    }
+
+    public Builder addItemType(Class<?> itemType) {
+      property.itemType = itemType;
+      return this;
+    }
+
+    public ListProperty build() {
+      assert property.getter != null;
+      assert property.setter != null;
+      assert property.itemType != null;
+
+      return property;
+    }
+
   }
 
 }

--- a/generic-messages/src/main/java/com/langtoun/messages/types/properties/ListProperty.java
+++ b/generic-messages/src/main/java/com/langtoun/messages/types/properties/ListProperty.java
@@ -4,7 +4,7 @@ import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
-public class ListProperty extends MessageProperty {
+public class ListProperty extends PayloadProperty {
 
   private final Supplier<List<Object>> getter;
   private final Consumer<List<Object>> setter;

--- a/generic-messages/src/main/java/com/langtoun/messages/types/properties/PayloadProperty.java
+++ b/generic-messages/src/main/java/com/langtoun/messages/types/properties/PayloadProperty.java
@@ -1,6 +1,6 @@
 package com.langtoun.messages.types.properties;
 
-public class MessageProperty {
+public class PayloadProperty {
 
   private final String name;
   private final String jsonName;
@@ -10,7 +10,7 @@ public class MessageProperty {
 
   private final Class<?> valueType;
 
-  protected MessageProperty(final String name, final String jsonName, final String xmlName, final boolean required, final Class<?> valueType) {
+  protected PayloadProperty(final String name, final String jsonName, final String xmlName, final boolean required, final Class<?> valueType) {
     super();
     this.name = name;
     this.jsonName = jsonName;

--- a/generic-messages/src/main/java/com/langtoun/messages/types/properties/ScalarProperty.java
+++ b/generic-messages/src/main/java/com/langtoun/messages/types/properties/ScalarProperty.java
@@ -5,32 +5,53 @@ import java.util.function.Supplier;
 
 public class ScalarProperty extends PayloadProperty {
 
-  private final Supplier<Object> getter;
-  private final Consumer<Object> setter;
+  private Supplier<Object> getter;
+  private Consumer<Object> setter;
 
-  protected ScalarProperty(final String name, final String jsonName, final String xmlName, final boolean required, final Supplier<Object> getter,
-      final Consumer<Object> setter, final Class<?> valueType) {
+  protected ScalarProperty(final String name, final String jsonName, final String xmlName, final boolean required,
+      final Class<?> valueType) {
     super(name, jsonName, xmlName, required, valueType);
-    this.getter = getter;
-    this.setter = setter;
   }
 
-  public static ScalarProperty newScalarProperty(final String name, final String jsonName, final String xmlName, final boolean required,
-      final Supplier<Object> getter, final Consumer<Object> setter, final Class<?> valueType) {
-    return new ScalarProperty(name, jsonName, xmlName, required, getter, setter, valueType);
-  }
+  public Supplier<Object> getGetter() { return getter; }
 
-  public Supplier<Object> getGetter() {
-    return getter;
-  }
-
-  public Consumer<Object> getSetter() {
-    return setter;
-  }
+  public Consumer<Object> getSetter() { return setter; }
 
   @Override
   public String toString() {
     return "scalarProp[super=" + super.toString() + "]]";
+  }
+
+  public static class Builder {
+
+    private static ScalarProperty property;
+
+    private Builder(final String name, final String jsonName, final String xmlName, final boolean required, Class<?> valueType) {
+      property = new ScalarProperty(name, jsonName, xmlName, required, valueType);
+    }
+
+    public static Builder newBuilder(final String name, final String jsonName, final String xmlName, final boolean required,
+        Class<?> valueType) {
+      return new Builder(name, jsonName, xmlName, required, valueType);
+    }
+
+    public Builder addGetter(Supplier<Object> getter) {
+      property.getter = getter;
+      return this;
+    }
+
+    public Builder addSetter(Consumer<Object> setter) {
+      property.setter = setter;
+      return this;
+    }
+
+    public ScalarProperty build() {
+      assert property.getter != null;
+      assert property.setter != null;
+
+      return property;
+    }
+
   }
 
 }

--- a/generic-messages/src/main/java/com/langtoun/messages/types/properties/ScalarProperty.java
+++ b/generic-messages/src/main/java/com/langtoun/messages/types/properties/ScalarProperty.java
@@ -3,7 +3,7 @@ package com.langtoun.messages.types.properties;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
-public class ScalarProperty extends MessageProperty {
+public class ScalarProperty extends PayloadProperty {
 
   private final Supplier<Object> getter;
   private final Consumer<Object> setter;

--- a/generic-messages/src/test/java/com/langtoun/messages/types/gen/cars/CarEngine.java
+++ b/generic-messages/src/test/java/com/langtoun/messages/types/gen/cars/CarEngine.java
@@ -1,7 +1,5 @@
 package com.langtoun.messages.types.gen.cars;
 
-import static com.langtoun.messages.types.properties.ScalarProperty.newScalarProperty;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -12,6 +10,7 @@ import com.langtoun.messages.generic.PayloadJsonDeserializer;
 import com.langtoun.messages.generic.PayloadJsonSerializer;
 import com.langtoun.messages.types.SerializablePayload;
 import com.langtoun.messages.types.properties.PayloadProperty;
+import com.langtoun.messages.types.properties.ScalarProperty;
 
 /**
  * Surrogate for a generated type that implements {@link SerializablePayload}.
@@ -25,7 +24,7 @@ public class CarEngine implements SerializablePayload {
   private String fuelType; // optional
 
   public CarEngine() {
-
+    // do nothing
   }
 
   public CarEngine(final Integer cylinders, final String fuelType) {
@@ -44,10 +43,10 @@ public class CarEngine implements SerializablePayload {
   @Override
   public List<PayloadProperty> getProperties() {
     return new ArrayList<>(Arrays.asList(
-        newScalarProperty("cylinders", "cylinders", "cylinders", true, () -> getCylinders(), o -> setCylinders((Integer) o),
-            Integer.class),
-        newScalarProperty("fuelType", "fuelType", "fuelType", false, () -> getFuelType(), o -> setFuelType((String) o),
-            String.class)));
+        ScalarProperty.Builder.newBuilder("cylinders", "cylinders", "cylinders", true, Integer.class)
+            .addGetter(() -> getCylinders()).addSetter(o -> setCylinders((Integer) o)).build(),
+        ScalarProperty.Builder.newBuilder("fuelType", "fuelType", "fuelType", false, String.class).addGetter(() -> getFuelType())
+            .addSetter(o -> setFuelType((String) o)).build()));
   }
 
   @Override

--- a/generic-messages/src/test/java/com/langtoun/messages/types/gen/cars/CarEngine.java
+++ b/generic-messages/src/test/java/com/langtoun/messages/types/gen/cars/CarEngine.java
@@ -8,17 +8,17 @@ import java.util.List;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.langtoun.messages.generic.MessageJsonDeserializer;
-import com.langtoun.messages.generic.MessageJsonSerializer;
+import com.langtoun.messages.generic.PayloadJsonDeserializer;
+import com.langtoun.messages.generic.PayloadJsonSerializer;
 import com.langtoun.messages.types.SerializablePayload;
-import com.langtoun.messages.types.properties.MessageProperty;
+import com.langtoun.messages.types.properties.PayloadProperty;
 
 /**
  * Surrogate for a generated type that implements {@link SerializablePayload}.
  *
  */
-@JsonSerialize(using = MessageJsonSerializer.class, as = CarEngine.class)
-@JsonDeserialize(using = MessageJsonDeserializer.class, as = CarEngine.class)
+@JsonSerialize(using = PayloadJsonSerializer.class, as = CarEngine.class)
+@JsonDeserialize(using = PayloadJsonDeserializer.class, as = CarEngine.class)
 public class CarEngine implements SerializablePayload {
 
   private Integer cylinders; // required
@@ -42,7 +42,7 @@ public class CarEngine implements SerializablePayload {
   public void setFuelType(final String fuelType) { this.fuelType = fuelType; }
 
   @Override
-  public List<MessageProperty> getProperties() {
+  public List<PayloadProperty> getProperties() {
     return new ArrayList<>(Arrays.asList(
         newScalarProperty("cylinders", "cylinders", "cylinders", true, () -> getCylinders(), o -> setCylinders((Integer) o),
             Integer.class),

--- a/generic-messages/src/test/java/com/langtoun/messages/types/gen/cars/CarFeature.java
+++ b/generic-messages/src/test/java/com/langtoun/messages/types/gen/cars/CarFeature.java
@@ -8,17 +8,17 @@ import java.util.List;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.langtoun.messages.generic.MessageJsonDeserializer;
-import com.langtoun.messages.generic.MessageJsonSerializer;
+import com.langtoun.messages.generic.PayloadJsonDeserializer;
+import com.langtoun.messages.generic.PayloadJsonSerializer;
 import com.langtoun.messages.types.SerializablePayload;
-import com.langtoun.messages.types.properties.MessageProperty;
+import com.langtoun.messages.types.properties.PayloadProperty;
 
 /**
  * Surrogate for a generated type that implements {@link SerializablePayload}.
  *
  */
-@JsonSerialize(using = MessageJsonSerializer.class, as = CarFeature.class)
-@JsonDeserialize(using = MessageJsonDeserializer.class, as = CarFeature.class)
+@JsonSerialize(using = PayloadJsonSerializer.class, as = CarFeature.class)
+@JsonDeserialize(using = PayloadJsonDeserializer.class, as = CarFeature.class)
 public class CarFeature implements SerializablePayload {
 
   private String name;
@@ -42,7 +42,7 @@ public class CarFeature implements SerializablePayload {
   public void setPrice(final Double price) { this.price = price; }
 
   @Override
-  public List<MessageProperty> getProperties() {
+  public List<PayloadProperty> getProperties() {
     return new ArrayList<>(
         Arrays.asList(newScalarProperty("name", "name", "name", true, () -> getName(), o -> setName((String) o), String.class),
             newScalarProperty("price", "price", "price", false, () -> getPrice(), o -> setPrice((Double) o), Double.class)));

--- a/generic-messages/src/test/java/com/langtoun/messages/types/gen/cars/CarFeature.java
+++ b/generic-messages/src/test/java/com/langtoun/messages/types/gen/cars/CarFeature.java
@@ -1,7 +1,5 @@
 package com.langtoun.messages.types.gen.cars;
 
-import static com.langtoun.messages.types.properties.ScalarProperty.newScalarProperty;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -12,6 +10,7 @@ import com.langtoun.messages.generic.PayloadJsonDeserializer;
 import com.langtoun.messages.generic.PayloadJsonSerializer;
 import com.langtoun.messages.types.SerializablePayload;
 import com.langtoun.messages.types.properties.PayloadProperty;
+import com.langtoun.messages.types.properties.ScalarProperty;
 
 /**
  * Surrogate for a generated type that implements {@link SerializablePayload}.
@@ -21,11 +20,11 @@ import com.langtoun.messages.types.properties.PayloadProperty;
 @JsonDeserialize(using = PayloadJsonDeserializer.class, as = CarFeature.class)
 public class CarFeature implements SerializablePayload {
 
-  private String name;
-  private Double price;
+  private String name; // required
+  private Double price; // optional
 
   public CarFeature() {
-
+    // do nothing
   }
 
   public CarFeature(final String name, final Double price) {
@@ -43,9 +42,11 @@ public class CarFeature implements SerializablePayload {
 
   @Override
   public List<PayloadProperty> getProperties() {
-    return new ArrayList<>(
-        Arrays.asList(newScalarProperty("name", "name", "name", true, () -> getName(), o -> setName((String) o), String.class),
-            newScalarProperty("price", "price", "price", false, () -> getPrice(), o -> setPrice((Double) o), Double.class)));
+    return new ArrayList<>(Arrays.asList(
+        ScalarProperty.Builder.newBuilder("name", "name", "name", true, String.class).addGetter(() -> getName())
+            .addSetter(o -> setName((String) o)).build(),
+        ScalarProperty.Builder.newBuilder("price", "price", "price", false, Double.class).addGetter(() -> getPrice())
+            .addSetter(o -> setPrice((Double) o)).build()));
   }
 
   @Override

--- a/generic-messages/src/test/java/com/langtoun/messages/types/gen/cars/ComplexCar.java
+++ b/generic-messages/src/test/java/com/langtoun/messages/types/gen/cars/ComplexCar.java
@@ -1,7 +1,5 @@
 package com.langtoun.messages.types.gen.cars;
 
-import static com.langtoun.messages.types.properties.ScalarProperty.newScalarProperty;
-
 import java.util.List;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -10,6 +8,7 @@ import com.langtoun.messages.generic.PayloadJsonDeserializer;
 import com.langtoun.messages.generic.PayloadJsonSerializer;
 import com.langtoun.messages.types.SerializablePayload;
 import com.langtoun.messages.types.properties.PayloadProperty;
+import com.langtoun.messages.types.properties.ScalarProperty;
 
 /**
  * Surrogate for a generated type that implements {@link SerializablePayload}.
@@ -22,7 +21,7 @@ public class ComplexCar extends SimpleCar {
   private CarEngine engine; // required
 
   public ComplexCar() {
-
+    // do nothing
   }
 
   public ComplexCar(final String colour, final String type, final Boolean rightHandDrive, final CarEngine engine) {
@@ -37,8 +36,8 @@ public class ComplexCar extends SimpleCar {
   @Override
   public List<PayloadProperty> getProperties() {
     final List<PayloadProperty> properties = super.getProperties();
-    properties.add(
-        newScalarProperty("engine", "engine", "engine", true, () -> getEngine(), o -> setEngine((CarEngine) o), CarEngine.class));
+    properties.add(ScalarProperty.Builder.newBuilder("engine", "engine", "engine", true, CarEngine.class)
+        .addGetter(() -> getEngine()).addSetter(o -> setEngine((CarEngine) o)).build());
     return properties;
   }
 

--- a/generic-messages/src/test/java/com/langtoun/messages/types/gen/cars/ComplexCar.java
+++ b/generic-messages/src/test/java/com/langtoun/messages/types/gen/cars/ComplexCar.java
@@ -6,17 +6,17 @@ import java.util.List;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.langtoun.messages.generic.MessageJsonDeserializer;
-import com.langtoun.messages.generic.MessageJsonSerializer;
+import com.langtoun.messages.generic.PayloadJsonDeserializer;
+import com.langtoun.messages.generic.PayloadJsonSerializer;
 import com.langtoun.messages.types.SerializablePayload;
-import com.langtoun.messages.types.properties.MessageProperty;
+import com.langtoun.messages.types.properties.PayloadProperty;
 
 /**
  * Surrogate for a generated type that implements {@link SerializablePayload}.
  *
  */
-@JsonSerialize(using = MessageJsonSerializer.class, as = ComplexCar.class)
-@JsonDeserialize(using = MessageJsonDeserializer.class, as = ComplexCar.class)
+@JsonSerialize(using = PayloadJsonSerializer.class, as = ComplexCar.class)
+@JsonDeserialize(using = PayloadJsonDeserializer.class, as = ComplexCar.class)
 public class ComplexCar extends SimpleCar {
 
   private CarEngine engine; // required
@@ -35,8 +35,8 @@ public class ComplexCar extends SimpleCar {
   public void setEngine(final CarEngine engine) { this.engine = engine; }
 
   @Override
-  public List<MessageProperty> getProperties() {
-    final List<MessageProperty> properties = super.getProperties();
+  public List<PayloadProperty> getProperties() {
+    final List<PayloadProperty> properties = super.getProperties();
     properties.add(
         newScalarProperty("engine", "engine", "engine", true, () -> getEngine(), o -> setEngine((CarEngine) o), CarEngine.class));
     return properties;

--- a/generic-messages/src/test/java/com/langtoun/messages/types/gen/cars/ComplexCarWithFeatures.java
+++ b/generic-messages/src/test/java/com/langtoun/messages/types/gen/cars/ComplexCarWithFeatures.java
@@ -1,7 +1,5 @@
 package com.langtoun.messages.types.gen.cars;
 
-import static com.langtoun.messages.types.properties.ListProperty.newListProperty;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -11,6 +9,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.langtoun.messages.generic.PayloadJsonDeserializer;
 import com.langtoun.messages.generic.PayloadJsonSerializer;
 import com.langtoun.messages.types.SerializablePayload;
+import com.langtoun.messages.types.properties.ListProperty;
 import com.langtoun.messages.types.properties.PayloadProperty;
 
 /**
@@ -21,15 +20,14 @@ import com.langtoun.messages.types.properties.PayloadProperty;
 @JsonDeserialize(using = PayloadJsonDeserializer.class, as = ComplexCarWithFeatures.class)
 public class ComplexCarWithFeatures extends ComplexCar {
 
-  private final List<CarFeature> features = new ArrayList<>();
+  private final List<CarFeature> features = new ArrayList<>(); // optional
 
   public ComplexCarWithFeatures() {
-    // TODO Auto-generated constructor stub
+    // do nothing
   }
 
   public ComplexCarWithFeatures(final String colour, final String type, final Boolean rightHandDrive, final CarEngine engine) {
     super(colour, type, rightHandDrive, engine);
-    // TODO Auto-generated constructor stub
   }
 
   public List<CarFeature> getFeatures() { return features; }
@@ -45,9 +43,9 @@ public class ComplexCarWithFeatures extends ComplexCar {
   @Override
   public List<PayloadProperty> getProperties() {
     final List<PayloadProperty> properties = super.getProperties();
-    properties.add(newListProperty("features", "features", "features", false,
-        () -> features != null ? features.stream().map(o -> (Object) o).collect(Collectors.toList()) : new ArrayList<>(),
-        l -> l.stream().map(o -> (CarFeature) o).forEach(o -> features.add(o)), List.class, CarFeature.class));
+    properties.add(ListProperty.Builder.newBuilder("features", "features", "features", false)
+        .addGetter(() -> features != null ? features.stream().map(o -> (Object) o).collect(Collectors.toList()) : new ArrayList<>())
+        .addSetter(l -> l.stream().map(o -> (CarFeature) o).forEach(o -> features.add(o))).addItemType(CarFeature.class).build());
     return properties;
   }
 

--- a/generic-messages/src/test/java/com/langtoun/messages/types/gen/cars/ComplexCarWithFeatures.java
+++ b/generic-messages/src/test/java/com/langtoun/messages/types/gen/cars/ComplexCarWithFeatures.java
@@ -8,17 +8,17 @@ import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.langtoun.messages.generic.MessageJsonDeserializer;
-import com.langtoun.messages.generic.MessageJsonSerializer;
+import com.langtoun.messages.generic.PayloadJsonDeserializer;
+import com.langtoun.messages.generic.PayloadJsonSerializer;
 import com.langtoun.messages.types.SerializablePayload;
-import com.langtoun.messages.types.properties.MessageProperty;
+import com.langtoun.messages.types.properties.PayloadProperty;
 
 /**
  * Surrogate for a generated type that implements {@link SerializablePayload}.
  *
  */
-@JsonSerialize(using = MessageJsonSerializer.class, as = ComplexCarWithFeatures.class)
-@JsonDeserialize(using = MessageJsonDeserializer.class, as = ComplexCarWithFeatures.class)
+@JsonSerialize(using = PayloadJsonSerializer.class, as = ComplexCarWithFeatures.class)
+@JsonDeserialize(using = PayloadJsonDeserializer.class, as = ComplexCarWithFeatures.class)
 public class ComplexCarWithFeatures extends ComplexCar {
 
   private final List<CarFeature> features = new ArrayList<>();
@@ -43,8 +43,8 @@ public class ComplexCarWithFeatures extends ComplexCar {
   }
 
   @Override
-  public List<MessageProperty> getProperties() {
-    final List<MessageProperty> properties = super.getProperties();
+  public List<PayloadProperty> getProperties() {
+    final List<PayloadProperty> properties = super.getProperties();
     properties.add(newListProperty("features", "features", "features", false,
         () -> features != null ? features.stream().map(o -> (Object) o).collect(Collectors.toList()) : new ArrayList<>(),
         l -> l.stream().map(o -> (CarFeature) o).forEach(o -> features.add(o)), List.class, CarFeature.class));

--- a/generic-messages/src/test/java/com/langtoun/messages/types/gen/cars/SimpleCar.java
+++ b/generic-messages/src/test/java/com/langtoun/messages/types/gen/cars/SimpleCar.java
@@ -8,17 +8,17 @@ import java.util.List;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.langtoun.messages.generic.MessageJsonDeserializer;
-import com.langtoun.messages.generic.MessageJsonSerializer;
+import com.langtoun.messages.generic.PayloadJsonDeserializer;
+import com.langtoun.messages.generic.PayloadJsonSerializer;
 import com.langtoun.messages.types.SerializablePayload;
-import com.langtoun.messages.types.properties.MessageProperty;
+import com.langtoun.messages.types.properties.PayloadProperty;
 
 /**
  * Surrogate for a generated type that implements {@link SerializablePayload}.
  *
  */
-@JsonSerialize(using = MessageJsonSerializer.class, as = SimpleCar.class)
-@JsonDeserialize(using = MessageJsonDeserializer.class, as = SimpleCar.class)
+@JsonSerialize(using = PayloadJsonSerializer.class, as = SimpleCar.class)
+@JsonDeserialize(using = PayloadJsonDeserializer.class, as = SimpleCar.class)
 public class SimpleCar implements SerializablePayload {
 
   private String colour; // required
@@ -48,7 +48,7 @@ public class SimpleCar implements SerializablePayload {
   public void setRightHandDrive(Boolean rightHandDrive) { this.rightHandDrive = rightHandDrive; }
 
   @Override
-  public List<MessageProperty> getProperties() {
+  public List<PayloadProperty> getProperties() {
     return new ArrayList<>(Arrays.asList(
         newScalarProperty("colour", "colour", "colour", true, () -> getColour(), o -> setColour((String) o), String.class),
         newScalarProperty("type", "type", "type", true, () -> getType(), o -> setType((String) o), String.class),

--- a/generic-messages/src/test/java/com/langtoun/messages/types/gen/cars/SimpleCar.java
+++ b/generic-messages/src/test/java/com/langtoun/messages/types/gen/cars/SimpleCar.java
@@ -1,7 +1,5 @@
 package com.langtoun.messages.types.gen.cars;
 
-import static com.langtoun.messages.types.properties.ScalarProperty.newScalarProperty;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -12,6 +10,7 @@ import com.langtoun.messages.generic.PayloadJsonDeserializer;
 import com.langtoun.messages.generic.PayloadJsonSerializer;
 import com.langtoun.messages.types.SerializablePayload;
 import com.langtoun.messages.types.properties.PayloadProperty;
+import com.langtoun.messages.types.properties.ScalarProperty;
 
 /**
  * Surrogate for a generated type that implements {@link SerializablePayload}.
@@ -26,7 +25,7 @@ public class SimpleCar implements SerializablePayload {
   private Boolean rightHandDrive; // optional
 
   public SimpleCar() {
-
+    // do nothing
   }
 
   public SimpleCar(final String colour, final String type, final Boolean rightHandDrive) {
@@ -50,10 +49,12 @@ public class SimpleCar implements SerializablePayload {
   @Override
   public List<PayloadProperty> getProperties() {
     return new ArrayList<>(Arrays.asList(
-        newScalarProperty("colour", "colour", "colour", true, () -> getColour(), o -> setColour((String) o), String.class),
-        newScalarProperty("type", "type", "type", true, () -> getType(), o -> setType((String) o), String.class),
-        newScalarProperty("rightHandDrive", "right_hand_drive", "rightHandDrive", false, () -> getRightHandDrive(),
-            o -> setRightHandDrive((Boolean) o), Boolean.class)));
+        ScalarProperty.Builder.newBuilder("colour", "colour", "colour", true, String.class).addGetter(() -> getColour())
+            .addSetter(o -> setColour((String) o)).build(),
+        ScalarProperty.Builder.newBuilder("type", "type", "type", true, String.class).addGetter(() -> getType())
+            .addSetter(o -> setType((String) o)).build(),
+        ScalarProperty.Builder.newBuilder("rightHandDrive", "right_hand_drive", "rightHandDrive", false, Boolean.class)
+            .addGetter(() -> getRightHandDrive()).addSetter(o -> setRightHandDrive((Boolean) o)).build()));
   }
 
   @Override


### PR DESCRIPTION
The builder pattern is being introduced to put the brakes on the ever growing list of constructor arguments that are being passed to the static factory methods. This change also refactors the names of the classes to replace references to Message with Payload.