### PR TITLE
Implement the custom codecs (delimiter based and GQL)

### DIFF
--- a/generic-messages/src/main/java/com/langtoun/messages/annotations/AwsFieldProperty.java
+++ b/generic-messages/src/main/java/com/langtoun/messages/annotations/AwsFieldProperty.java
@@ -10,8 +10,10 @@ import com.langtoun.messages.types.FieldEncodingType;
 
 /**
  * An annotation that can be added to fields that are to participate in
- * serialization / deserialization. Fields that are not annotated or that don't
- * define a name for the serialization being processed are ignored.
+ * serialization / deserialization. The annotation allows the field to be
+ * configured as required/optional and sensitive/non-sensitive. If the type that
+ * contains the field is subject to a custom encoding then the field's encoding
+ * can be specified using this annotation.
  */
 @Retention(RUNTIME)
 @Target(FIELD)
@@ -30,29 +32,6 @@ public @interface AwsFieldProperty {
    * @return {@code true} if the field is sensitive, otherwise {@code false}
    */
   boolean isSensitive() default false;
-
-  /**
-   * The name of the field as it should appear in a JSON serialization.
-   * 
-   * @return the JSON property name
-   */
-  String jsonName() default "";
-
-  /**
-   * The name of the field as it should appear in an XML serialization.
-   * 
-   * @return the XML element name
-   */
-  String xmlName() default "";
-
-  /**
-   * The name of the field as it appeared in the API specification. It may not
-   * match the field name if it used characters or conventions that are not
-   * supported for Java identifiers.
-   * 
-   * @return the original field name from the API specification
-   */
-  String originalName() default "";
 
   /**
    * If the field is a member of a type that is subject to custom encoding then

--- a/generic-messages/src/main/java/com/langtoun/messages/generic/AwsComplexTypeJsonDeserializer.java
+++ b/generic-messages/src/main/java/com/langtoun/messages/generic/AwsComplexTypeJsonDeserializer.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.BeanProperty;
 import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonMappingException;
@@ -34,9 +35,9 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.ValueNode;
 import com.google.common.collect.Streams;
-import com.langtoun.messages.annotations.CustomTypeEncoding;
-import com.langtoun.messages.annotations.AwsTypeDefinition;
 import com.langtoun.messages.annotations.AwsFieldProperty;
+import com.langtoun.messages.annotations.AwsTypeDefinition;
+import com.langtoun.messages.annotations.CustomTypeEncoding;
 import com.langtoun.messages.types.AwsComplexType;
 import com.langtoun.messages.types.CustomTypeCodec;
 import com.langtoun.messages.types.FieldEncodingType;
@@ -50,6 +51,11 @@ import com.langtoun.messages.util.SerializationUtil;
 public class AwsComplexTypeJsonDeserializer extends JsonDeserializer<AwsComplexType> implements ContextualDeserializer {
 
   private static final ObjectMapper objectMapper = new ObjectMapper();
+
+  static {
+    objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+  }
 
   private JavaType javaType;
 
@@ -139,19 +145,17 @@ public class AwsComplexTypeJsonDeserializer extends JsonDeserializer<AwsComplexT
          * find each property in turn and populate the payload, creating new payload
          * objects as the deserializer walks the node tree
          */
-        final String jsonName = property.jsonName();
         final Class<?> fieldType = field.getType();
-        final JsonNode jsonField = rootNode.findValue(jsonName);
+        final JsonNode jsonField = rootNode.findValue(fieldName);
         if (jsonField != null) {
           if (List.class.isAssignableFrom(fieldType)) {
             if (jsonField instanceof ArrayNode) {
-              System.out.println(indent + jsonName + "[]");
+              System.out.println(indent + fieldName + "[]");
               SerializationUtil.setValue(value, readArrayValues((ArrayNode) jsonField, field, property, nodePath, indent + "  "),
                   field);
             } else {
-              throw new IllegalStateException(
-                  String.format("%s%s: failed to process list property for type[%s], field[%s] (JSON property name = %s)", nodePath,
-                      jsonName, value.getClass().getTypeName(), field.getName(), jsonName));
+              throw new IllegalStateException(String.format("%s%s: failed to process list property for type[%s], field[%s]",
+                  nodePath, fieldName, value.getClass().getTypeName(), fieldName));
             }
           } else {
             /*
@@ -160,12 +164,16 @@ public class AwsComplexTypeJsonDeserializer extends JsonDeserializer<AwsComplexT
             SerializationUtil.setValue(value, readScalarValue(jsonField, fieldName, field, nodePath, indent), field);
           }
         } else if (property.required()) {
-          System.out.println(indent + jsonName + " - required (not present)");
+          System.out.println(indent + fieldName + " - required (not present)");
           throw new IllegalStateException(String.format("%s%s: missing required property for type[%s], field[%s]", nodePath,
               fieldName, value.getClass().getTypeName(), field.getName()));
         } else {
-          System.out.println(indent + jsonName + " - optional (not present)");
+          System.out.println(indent + fieldName + " - optional (not present)");
         }
+      } else {
+        throw new IllegalStateException(
+            String.format("failed to retrieve field property info during serialization of type[%s], field[%s]",
+                value.getClass().getTypeName(), fieldName));
       }
     }
     return value;
@@ -173,7 +181,7 @@ public class AwsComplexTypeJsonDeserializer extends JsonDeserializer<AwsComplexT
 
   private static List<Object> readArrayValues(final ArrayNode arrayNode, final Field field, final AwsFieldProperty property,
       final String nodePath, final String indent) {
-    final String fieldName = property.jsonName();
+    final String fieldName = field.getName();
     final Iterator<JsonNode> iter = arrayNode.elements();
     if (iter.hasNext()) {
       int i = 0;
@@ -225,15 +233,17 @@ public class AwsComplexTypeJsonDeserializer extends JsonDeserializer<AwsComplexT
 
   private static AwsComplexType deserializeCustomEncoding(final AwsComplexType value, final String encoded,
       final AwsTypeDefinition typeDefinition) {
-    final String valueTypeName = value.getClass().getTypeName();
     String remaining = encoded;
+    if (remaining.startsWith("\"") && remaining.endsWith("\"")) {
+      remaining = remaining.substring(1, remaining.length() - 1);
+    }
     final CustomTypeEncoding typeEncoding = typeDefinition.encoding();
     /*
      * check and consume the prefix
      */
     if (!typeEncoding.prefix().isEmpty()) {
       remaining = consumeRequiredTokenAtStart(remaining, typeEncoding.prefix(), () -> {
-        return String.format("encoded[%s] must have prefix[%s]", valueTypeName, typeEncoding.prefix());
+        return String.format("encoded[%s] must have prefix[%s]", value.getClass().getTypeName(), typeEncoding.prefix());
       });
     }
     /*
@@ -241,7 +251,7 @@ public class AwsComplexTypeJsonDeserializer extends JsonDeserializer<AwsComplexT
      */
     if (!typeEncoding.suffix().isEmpty()) {
       remaining = consumeRequiredTokenAtEnd(remaining, typeEncoding.suffix(), () -> {
-        return String.format("encoded[%s] must have suffix[%s]", valueTypeName, typeEncoding.suffix());
+        return String.format("encoded[%s] must have suffix[%s]", value.getClass().getTypeName(), typeEncoding.suffix());
       });
     }
     /*
@@ -269,8 +279,8 @@ public class AwsComplexTypeJsonDeserializer extends JsonDeserializer<AwsComplexT
           encodedFieldMap.put(encodedField.substring(0, keyValSepIndex).trim(),
               encodedField.substring(keyValSepIndex + keyValSep.length()).trim());
         } else {
-          throw new IllegalArgumentException(
-              String.format("no key/value separator[%s] found in entry[%s] for type[%s]", keyValSep, encodedField, valueTypeName));
+          throw new IllegalArgumentException(String.format("no key/value separator[%s] found in entry[%s] for type[%s]", keyValSep,
+              encodedField, value.getClass().getTypeName()));
         }
       } else {
         encodedFieldMap.put(fieldOrder[i], encodedField);
@@ -288,22 +298,20 @@ public class AwsComplexTypeJsonDeserializer extends JsonDeserializer<AwsComplexT
 //      if (!ignoredField) { // due to preprocessor directives
 
       final Pair<Field, AwsFieldProperty> fieldProperty = fieldProperties.get(fieldName);
-      final Field field = fieldProperty.getKey();
-      final AwsFieldProperty property = fieldProperty.getValue();
-      final Class<?> fieldType = field.getType();
-      final boolean repeated = List.class.isAssignableFrom(fieldType);
+      if (fieldProperty != null) {
+        final Field field = fieldProperty.getKey();
+        final AwsFieldProperty property = fieldProperty.getValue();
+        final Class<?> fieldType = field.getType();
+        final boolean repeated = List.class.isAssignableFrom(fieldType);
 
-      try {
-        if (keyValSep.isEmpty()) {
-          // TODO: work out wtf is going on here
-        } else {
+        try {
           /*
            * retrieve the encoded field and take action if it's a missing required field
            */
           encodedField = encodedFieldMap.get(fieldName);
           if (encodedField == null && property.required()) {
-            throw new IllegalArgumentException(
-                String.format("failed to find an entry for required field[%s] in type[%s]", fieldName, valueTypeName));
+            throw new IllegalArgumentException(String.format("failed to find an entry for required field[%s] in type[%s]",
+                fieldName, value.getClass().getTypeName()));
           }
           if (encodedField != null) {
             final FieldEncodingType fieldEncoding = property.encoding();
@@ -320,8 +328,9 @@ public class AwsComplexTypeJsonDeserializer extends JsonDeserializer<AwsComplexT
                 final JAXBContext jaxbContext = SerializationUtil.getJaxbContextFor((Class<?>) (repeated ? List.class : fieldType));
                 final InputStream xmlStream = new java.io.ByteArrayInputStream(encodedField.getBytes());
                 final Unmarshaller unmarshaller = jaxbContext.createUnmarshaller();
-                SerializationUtil.setValue(valueTypeName, unmarshaller.unmarshal(xmlStream), field);
-                // SerializationUtil.setValue(com.avaloq.front.common.util.SafeXMLUtils.safeUnmarshal(xmlStream,
+                SerializationUtil.setValue(value, unmarshaller.unmarshal(xmlStream), field);
+                // SerializationUtil.setValue(value,
+                // com.avaloq.front.common.util.SafeXMLUtils.safeUnmarshal(xmlStream,
                 // jaxbContext), field);
               } else if (fieldEncoding == FieldEncodingType.JSON || fieldEncoding == FieldEncodingType.JSON_URLENCODED) {
                 SerializationUtil.setValue(value,
@@ -342,29 +351,35 @@ public class AwsComplexTypeJsonDeserializer extends JsonDeserializer<AwsComplexT
                     .getJaxbContextFor((Class<?>) (repeated ? List.class : fieldType));
                 java.io.InputStream xmlStream = new java.io.ByteArrayInputStream(encodedField.getBytes());
                 final Unmarshaller unmarshaller = jaxbContext.createUnmarshaller();
-                SerializationUtil.setValue(valueTypeName, unmarshaller.unmarshal(xmlStream), field);
-                // SerializationUtil.setValue(com.avaloq.front.common.util.SafeXMLUtils.safeUnmarshal(xmlStream,
+                SerializationUtil.setValue(value, unmarshaller.unmarshal(xmlStream), field);
+                // SerializationUtil.setValue(value,
+                // com.avaloq.front.common.util.SafeXMLUtils.safeUnmarshal(xmlStream,
                 // jaxbContext), field);
               } else {
                 if (!AwsComplexType.class.isAssignableFrom(fieldType)) {
-                  SerializationUtil.setValue(valueTypeName, SerializationUtil.coerceFromString(encodedField, fieldType), field);
+                  SerializationUtil.setValue(value, SerializationUtil.coerceFromString(encodedField, fieldType), field);
                 } else {
-                  throw new IllegalArgumentException(String
-                      .format("unable to deserialize an instance of type[%s] from encoded field[%s]", valueTypeName, encodedField));
+                  throw new IllegalArgumentException(
+                      String.format("unable to deserialize an instance of type[%s] from encoded field[%s]",
+                          value.getClass().getTypeName(), encodedField));
                 }
               }
             }
+
           }
 
+        } catch (Exception e) {
+          if (e instanceof IllegalArgumentException) {
+            throw (IllegalArgumentException) e;
+          } else {
+            throw new IllegalArgumentException(String.format("failed to decode encoded field[%s] for type[%s], field[%s]",
+                encodedField, value.getClass().getTypeName(), fieldName), e);
+          }
         }
-
-      } catch (Exception e) {
-        if (e instanceof IllegalArgumentException) {
-          throw (IllegalArgumentException) e;
-        } else {
-          throw new IllegalArgumentException(
-              String.format("failed to decode property[%s] for type[%s], field[%s]", encodedField, valueTypeName, fieldName), e);
-        }
+      } else {
+        throw new IllegalStateException(
+            String.format("failed to retrieve field property info during serialization of type[%s], field[%s]",
+                value.getClass().getTypeName(), fieldName));
       }
 
 //      } // end of ignoredField

--- a/generic-messages/src/main/java/com/langtoun/messages/generic/AwsComplexTypeJsonDeserializer.java
+++ b/generic-messages/src/main/java/com/langtoun/messages/generic/AwsComplexTypeJsonDeserializer.java
@@ -10,7 +10,6 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Supplier;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
@@ -242,7 +241,7 @@ public class AwsComplexTypeJsonDeserializer extends JsonDeserializer<AwsComplexT
      * check and consume the prefix
      */
     if (!typeEncoding.prefix().isEmpty()) {
-      remaining = consumeRequiredTokenAtStart(remaining, typeEncoding.prefix(), () -> {
+      remaining = SerializationUtil.consumeRequiredTokenAtStart(remaining, typeEncoding.prefix(), () -> {
         return String.format("encoded[%s] must have prefix[%s]", value.getClass().getTypeName(), typeEncoding.prefix());
       });
     }
@@ -250,7 +249,7 @@ public class AwsComplexTypeJsonDeserializer extends JsonDeserializer<AwsComplexT
      * check and consume the suffix
      */
     if (!typeEncoding.suffix().isEmpty()) {
-      remaining = consumeRequiredTokenAtEnd(remaining, typeEncoding.suffix(), () -> {
+      remaining = SerializationUtil.consumeRequiredTokenAtEnd(remaining, typeEncoding.suffix(), () -> {
         return String.format("encoded[%s] must have suffix[%s]", value.getClass().getTypeName(), typeEncoding.suffix());
       });
     }
@@ -385,20 +384,6 @@ public class AwsComplexTypeJsonDeserializer extends JsonDeserializer<AwsComplexT
 //      } // end of ignoredField
     }
     return value;
-  }
-
-  private static String consumeRequiredTokenAtStart(final String encoded, final String token, Supplier<String> exceptionMessage) {
-    if (encoded.startsWith(token)) {
-      return encoded.substring(token.length());
-    }
-    throw new IllegalStateException(exceptionMessage.get());
-  }
-
-  private static String consumeRequiredTokenAtEnd(final String encoded, final String token, Supplier<String> exceptionMessage) {
-    if (encoded.endsWith(token)) {
-      return encoded.substring(0, encoded.length() - token.length());
-    }
-    throw new IllegalStateException(exceptionMessage.get());
   }
 
 }

--- a/generic-messages/src/main/java/com/langtoun/messages/generic/AwsComplexTypeJsonSerializer.java
+++ b/generic-messages/src/main/java/com/langtoun/messages/generic/AwsComplexTypeJsonSerializer.java
@@ -1,33 +1,19 @@
 package com.langtoun.messages.generic;
 
 import java.io.IOException;
-import java.io.StringWriter;
-import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Field;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Marshaller;
-
-import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.tuple.Pair;
 
 import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializerProvider;
-import com.langtoun.messages.annotations.CustomTypeEncoding;
-import com.langtoun.messages.annotations.AwsTypeDefinition;
 import com.langtoun.messages.annotations.AwsFieldProperty;
+import com.langtoun.messages.annotations.AwsTypeDefinition;
 import com.langtoun.messages.types.AwsComplexType;
-import com.langtoun.messages.types.CustomTypeCodec;
-import com.langtoun.messages.types.FieldEncodingType;
 import com.langtoun.messages.util.SerializationUtil;
 
 /**
@@ -36,12 +22,10 @@ import com.langtoun.messages.util.SerializationUtil;
  */
 public class AwsComplexTypeJsonSerializer extends JsonSerializer<AwsComplexType> {
 
-  private static final ObjectMapper objectMapper = new ObjectMapper();
-
   @Override
-  public void serialize(final AwsComplexType payload, final JsonGenerator gen, final SerializerProvider serializers)
+  public void serialize(final AwsComplexType value, final JsonGenerator gen, final SerializerProvider serializers)
       throws IOException {
-    serialize(payload, gen);
+    serialize(value, gen);
   }
 
   private static void serialize(final AwsComplexType value, final JsonGenerator gen) throws IOException {
@@ -50,10 +34,12 @@ public class AwsComplexTypeJsonSerializer extends JsonSerializer<AwsComplexType>
      */
     final AwsTypeDefinition typeDefinition = SerializationUtil.getTypeDefinition(value);
     if (typeDefinition != null) {
-      if (SerializationUtil.usesCustomTypeEncoding(typeDefinition.encoding())) {
-        gen.writeString(serializeCustomEncoding(value, typeDefinition));
-      } else {
+      if (!SerializationUtil.usesCustomTypeEncoding(typeDefinition.encoding())) {
         serializeComplexType(value, typeDefinition, gen);
+      } else {
+        throw new IllegalArgumentException(
+            String.format("the @TypeDefinition annotation must not specify custom encoding parameters for type[%s]",
+                value.getClass().getTypeName()));
       }
     } else {
       throw new IllegalArgumentException(
@@ -61,41 +47,8 @@ public class AwsComplexTypeJsonSerializer extends JsonSerializer<AwsComplexType>
     }
   }
 
-  public static String serializeCustomEncoding(final AwsComplexType value) {
-    /*
-     * check that the type is annotated with TypeDefinition
-     */
-    final AwsTypeDefinition typeDefinition = SerializationUtil.getTypeDefinition(value);
-    if (typeDefinition != null) {
-      return serializeCustomEncoding(value, SerializationUtil.getTypeDefinition(value));
-    } else {
-      throw new IllegalArgumentException(
-          String.format("type[%s] must be annotated with @TypeDefinition", value.getClass().getTypeName()));
-    }
-  }
-
-  private static String serializeCustomEncoding(final AwsComplexType value, final AwsTypeDefinition typeDefinition) {
-    final StringBuilder encoded = new StringBuilder();
-    if (typeDefinition.encoding().codec() == CustomTypeCodec.GQL) {
-      /*
-       * process using the GQL serializer
-       */
-      throw new UnsupportedOperationException("TODO: implement the GQL codec"); // TODO: implement the GQL codec
-    } else if (typeDefinition.encoding().codec() == CustomTypeCodec.STD) {
-      /*
-       * process using the prefix, suffix, field separator, and key / value separator
-       * specified in the annotation
-       */
-      serializeCustomEncoding(value, typeDefinition, encoded);
-    } else {
-      throw new IllegalArgumentException(String.format("cannot serialize type[%s] with unknown custom codec[%s]",
-          value.getClass().getTypeName(), typeDefinition.encoding().codec().customCodec));
-    }
-    return encoded.toString();
-  }
-
-  private static void serializeComplexType(final AwsComplexType value, final AwsTypeDefinition typeDefinition, final JsonGenerator gen)
-      throws IOException {
+  private static void serializeComplexType(final AwsComplexType value, final AwsTypeDefinition typeDefinition,
+      final JsonGenerator gen) throws IOException {
     if (value != null) {
       /*
        * open a new object
@@ -112,18 +65,24 @@ public class AwsComplexTypeJsonSerializer extends JsonSerializer<AwsComplexType>
        */
       for (final String fieldName : fieldOrder) {
         final Pair<Field, AwsFieldProperty> fieldProperty = fieldProperties.get(fieldName);
-        final Field field = fieldProperty.getKey();
-        final AwsFieldProperty property = fieldProperty.getValue();
-        if (List.class.isAssignableFrom(field.getType())) {
-          writeArrayValues(property.jsonName(), SerializationUtil.getListValue(value, field), property.required(), gen);
-        } else {
-          final Object fieldValue = SerializationUtil.getValue(value, field);
-          if (fieldValue instanceof AwsComplexType) {
-            gen.writeFieldName(property.jsonName());
-            serialize((AwsComplexType) fieldValue, gen);
+        if (fieldProperty != null) {
+          final Field field = fieldProperty.getKey();
+          final AwsFieldProperty property = fieldProperty.getValue();
+          if (List.class.isAssignableFrom(field.getType())) {
+            writeArrayValues(fieldName, SerializationUtil.getListValue(value, field), property.required(), gen);
           } else {
-            writeScalarValue(property.jsonName(), fieldValue, property.required(), gen);
+            final Object fieldValue = SerializationUtil.getValue(value, field);
+            if (fieldValue instanceof AwsComplexType) {
+              gen.writeFieldName(fieldName);
+              serialize((AwsComplexType) fieldValue, gen);
+            } else {
+              writeScalarValue(fieldName, fieldValue, property.required(), gen);
+            }
           }
+        } else {
+          throw new IllegalStateException(
+              String.format("failed to retrieve field property info during serialization of type[%s], field[%s]",
+                  value.getClass().getTypeName(), fieldName));
         }
       }
       /*
@@ -194,115 +153,6 @@ public class AwsComplexTypeJsonSerializer extends JsonSerializer<AwsComplexType>
       throw new IllegalStateException(
           String.format("attempt to serialize unknown value type[%s]", value.getClass().getSimpleName()));
     }
-  }
-
-  private static StringBuilder serializeCustomEncoding(final AwsComplexType value, final AwsTypeDefinition typeDefinition,
-      final StringBuilder encoded) {
-    final CustomTypeEncoding typeEncoding = typeDefinition.encoding();
-    /*
-     * write out the prefix if present
-     */
-    if (!typeEncoding.prefix().isEmpty()) {
-      encoded.append(typeEncoding.prefix());
-    }
-    /*
-     * encode each field in the order specified in the computed field order
-     */
-    final Map<String, Pair<Field, AwsFieldProperty>> fieldProperties = SerializationUtil
-        .getHierarchyFieldsWithTypeProperty(value.getClass());
-    final String[] fieldOrder = SerializationUtil.computeFieldOrder(typeDefinition, fieldProperties);
-    /*
-     * iterate over the fields that are to be encoded
-     */
-    int index = 0;
-    for (final String fieldName : fieldOrder) {
-      final Pair<Field, AwsFieldProperty> fieldProperty = fieldProperties.get(fieldName);
-      final Field field = fieldProperty.getKey();
-      final AwsFieldProperty property = fieldProperty.getValue();
-      final Class<?> fieldType = field.getType();
-      final boolean repeated = List.class.isAssignableFrom(fieldType);
-
-      String encodedValue = null;
-
-      if (AwsComplexType.class.isAssignableFrom(fieldType)) { // --- complex type ---
-        final FieldEncodingType fieldEncoding = property.encoding();
-        if (fieldEncoding != null) {
-          final Object fieldValue = SerializationUtil.getValue(value, field);
-          if (fieldEncoding == FieldEncodingType.XML || fieldEncoding == FieldEncodingType.XML_URLENCODED) {
-            try {
-              final JAXBContext jaxbContext = SerializationUtil.getJaxbContextFor(fieldType);
-              final Marshaller marshaller = jaxbContext.createMarshaller();
-              marshaller.setProperty(Marshaller.JAXB_FRAGMENT, Boolean.TRUE);
-              final StringWriter writer = new StringWriter();
-              marshaller.marshal(fieldValue, writer);
-              encodedValue = writer.toString();
-              if (fieldEncoding == FieldEncodingType.XML_URLENCODED) {
-                encodedValue = URLEncoder.encode(encodedValue, "UTF-8");
-              }
-            } catch (JAXBException | UnsupportedEncodingException e) {
-              throw new IllegalArgumentException(
-                  String.format("unable to serialize an field value of type[%s]", fieldType.getTypeName()), e);
-            }
-          } else if (fieldEncoding == FieldEncodingType.JSON || fieldEncoding == FieldEncodingType.JSON_URLENCODED
-              || fieldEncoding == FieldEncodingType.BASE64) {
-            try {
-              encodedValue = objectMapper.writeValueAsString(fieldValue);
-              if (fieldEncoding == FieldEncodingType.JSON_URLENCODED) {
-                encodedValue = URLEncoder.encode(encodedValue, "UTF-8");
-              } else if (fieldEncoding == FieldEncodingType.JSON_URLENCODED) {
-                encodedValue = Base64.encodeBase64URLSafeString(encodedValue.getBytes(StandardCharsets.UTF_8));
-              }
-            } catch (JsonProcessingException | UnsupportedEncodingException e) {
-              throw new IllegalArgumentException(String.format("unable to serialize an instance of type[%s], field[%s]",
-                  value.getClass().getTypeName(), field.getName()), e);
-            }
-          } else {
-            throw new IllegalArgumentException(String.format("unable to serialize an instance of type[%s], field[%s]",
-                value.getClass().getTypeName(), field.getName()));
-          }
-        } else {
-          throw new IllegalArgumentException(
-              String.format("unable to serialize an instance of type[%s], field[%s] - no encoding defined",
-                  value.getClass().getTypeName(), field.getName()));
-        }
-      } else { // --- simple type ---
-        Object object = null;
-        if (repeated) {
-          object = SerializationUtil.getListValue(value, field);
-        } else {
-          object = SerializationUtil.getValue(value, field);
-        }
-        if (object != null) {
-          encodedValue = object.toString();
-        }
-      }
-      /*
-       * write out a fieldSep if present and required
-       */
-      if (index > 0 && typeEncoding.fieldSep().length > 0) {
-        encoded.append(typeEncoding.fieldSep()[0]);
-      }
-      /*
-       * if the keyValSep has been specified write out the field name followed by the
-       * keyValSep
-       */
-      if (!typeEncoding.keyValSep().isEmpty()) {
-        encoded.append(property.originalName()).append(typeEncoding.keyValSep());
-      }
-      /*
-       * regardless of the encoding components that were / were not specified, the
-       * encoded value must always be written
-       */
-      encoded.append(encodedValue);
-      index++;
-    }
-    /*
-     * write out the suffix if present
-     */
-    if (!typeEncoding.suffix().isEmpty()) {
-      encoded.append(typeEncoding.suffix());
-    }
-    return encoded;
   }
 
 }

--- a/generic-messages/src/main/java/com/langtoun/messages/generic/AwsCustomEncodingSerializer.java
+++ b/generic-messages/src/main/java/com/langtoun/messages/generic/AwsCustomEncodingSerializer.java
@@ -1,0 +1,221 @@
+package com.langtoun.messages.generic;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.UnsupportedEncodingException;
+import java.lang.reflect.Field;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Marshaller;
+
+import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.lang3.tuple.Pair;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.langtoun.messages.annotations.AwsFieldProperty;
+import com.langtoun.messages.annotations.AwsTypeDefinition;
+import com.langtoun.messages.annotations.CustomTypeEncoding;
+import com.langtoun.messages.types.AwsComplexType;
+import com.langtoun.messages.types.CustomTypeCodec;
+import com.langtoun.messages.types.FieldEncodingType;
+import com.langtoun.messages.util.SerializationUtil;
+
+/**
+ * Customencoding serializer for types that handles data that may already have
+ * been serialized as well as types that extend the {@link AwsComplexType} base
+ * class.
+ *
+ */
+public class AwsCustomEncodingSerializer extends JsonSerializer<Object> {
+
+  private static final ObjectMapper objectMapper = new ObjectMapper();
+
+  @Override
+  public void serialize(final Object _object, final JsonGenerator gen, final SerializerProvider serializers) throws IOException {
+    serialize(_object, gen);
+  }
+
+  private static void serialize(final Object _object, final JsonGenerator gen) throws IOException {
+    /*
+     * check that the type is annotated with TypeDefinition
+     */
+    final AwsTypeDefinition typeDefinition = SerializationUtil.getTypeDefinition(_object);
+    if (typeDefinition != null) {
+      if (SerializationUtil.usesCustomTypeEncoding(typeDefinition.encoding())) {
+        if (_object instanceof String) {
+          /*
+           * value has already been serialized e.g. due to XmlJavaTypeAdapter
+           */
+          gen.writeString((String) _object);
+        } else {
+          gen.writeString(serializeCustomEncoding((AwsComplexType) _object, typeDefinition));
+        }
+      } else {
+        throw new IllegalArgumentException(
+            String.format("the @TypeDefinition annotation must specify custom encoding parameters for type[%s]",
+                _object.getClass().getTypeName()));
+      }
+    } else {
+      throw new IllegalArgumentException(
+          String.format("type[%s] must be annotated with @TypeDefinition", _object.getClass().getTypeName()));
+    }
+  }
+
+  public static String serializeCustomEncoding(final AwsComplexType value) {
+    /*
+     * check that the type is annotated with TypeDefinition
+     */
+    final AwsTypeDefinition typeDefinition = SerializationUtil.getTypeDefinition(value);
+    if (typeDefinition != null) {
+      return serializeCustomEncoding(value, SerializationUtil.getTypeDefinition(value));
+    } else {
+      throw new IllegalArgumentException(
+          String.format("type[%s] must be annotated with @TypeDefinition", value.getClass().getTypeName()));
+    }
+  }
+
+  private static String serializeCustomEncoding(final AwsComplexType value, final AwsTypeDefinition typeDefinition) {
+    final StringBuilder encoded = new StringBuilder();
+    if (typeDefinition.encoding().codec() == CustomTypeCodec.GQL) {
+      /*
+       * process using the GQL serializer
+       */
+      throw new UnsupportedOperationException("TODO: implement the GQL codec"); // TODO: implement the GQL codec
+    } else if (typeDefinition.encoding().codec() == CustomTypeCodec.STD) {
+      /*
+       * process using the prefix, suffix, field separator, and key / value separator
+       * specified in the annotation
+       */
+      serializeCustomEncoding(value, typeDefinition, encoded);
+    } else {
+      throw new IllegalArgumentException(String.format("cannot serialize type[%s] with unknown custom codec[%s]",
+          value.getClass().getTypeName(), typeDefinition.encoding().codec().customCodec));
+    }
+    return encoded.toString();
+  }
+
+  private static StringBuilder serializeCustomEncoding(final AwsComplexType value, final AwsTypeDefinition typeDefinition,
+      final StringBuilder encoded) {
+    final CustomTypeEncoding typeEncoding = typeDefinition.encoding();
+    /*
+     * write out the prefix if present
+     */
+    if (!typeEncoding.prefix().isEmpty()) {
+      encoded.append(typeEncoding.prefix());
+    }
+    /*
+     * encode each field in the order specified in the computed field order
+     */
+    final Map<String, Pair<Field, AwsFieldProperty>> fieldProperties = SerializationUtil
+        .getHierarchyFieldsWithTypeProperty(value.getClass());
+    final String[] fieldOrder = SerializationUtil.computeFieldOrder(typeDefinition, fieldProperties);
+    /*
+     * iterate over the fields that are to be encoded
+     */
+    int index = 0;
+    for (final String fieldName : fieldOrder) {
+      final Pair<Field, AwsFieldProperty> fieldProperty = fieldProperties.get(fieldName);
+      if (fieldProperty != null) {
+        final Field field = fieldProperty.getKey();
+        final AwsFieldProperty property = fieldProperty.getValue();
+        final Class<?> fieldType = field.getType();
+        final boolean repeated = List.class.isAssignableFrom(fieldType);
+
+        String encodedValue = null;
+
+        if (AwsComplexType.class.isAssignableFrom(fieldType)) { // --- complex type ---
+          final FieldEncodingType fieldEncoding = property.encoding();
+          if (fieldEncoding != null) {
+            final Object fieldValue = SerializationUtil.getValue(value, field);
+            if (fieldEncoding == FieldEncodingType.XML || fieldEncoding == FieldEncodingType.XML_URLENCODED) {
+              try {
+                final JAXBContext jaxbContext = SerializationUtil.getJaxbContextFor(fieldType);
+                final Marshaller marshaller = jaxbContext.createMarshaller();
+                marshaller.setProperty(Marshaller.JAXB_FRAGMENT, Boolean.TRUE);
+                final StringWriter writer = new StringWriter();
+                marshaller.marshal(fieldValue, writer);
+                encodedValue = writer.toString();
+                if (fieldEncoding == FieldEncodingType.XML_URLENCODED) {
+                  encodedValue = URLEncoder.encode(encodedValue, "UTF-8");
+                }
+              } catch (JAXBException | UnsupportedEncodingException e) {
+                throw new IllegalArgumentException(
+                    String.format("unable to serialize a field value of type[%s]", fieldType.getTypeName()), e);
+              }
+            } else if (fieldEncoding == FieldEncodingType.JSON || fieldEncoding == FieldEncodingType.JSON_URLENCODED
+                || fieldEncoding == FieldEncodingType.BASE64) {
+              try {
+                encodedValue = objectMapper.writeValueAsString(fieldValue);
+                if (fieldEncoding == FieldEncodingType.JSON_URLENCODED) {
+                  encodedValue = URLEncoder.encode(encodedValue, "UTF-8");
+                } else if (fieldEncoding == FieldEncodingType.BASE64) {
+                  encodedValue = Base64.encodeBase64URLSafeString(encodedValue.getBytes(StandardCharsets.UTF_8));
+                }
+              } catch (JsonProcessingException | UnsupportedEncodingException e) {
+                throw new IllegalArgumentException(String.format("unable to serialize an instance of type[%s], field[%s]",
+                    value.getClass().getTypeName(), field.getName()), e);
+              }
+            } else {
+              throw new IllegalArgumentException(String.format("unable to serialize an instance of type[%s], field[%s]",
+                  value.getClass().getTypeName(), field.getName()));
+            }
+          } else {
+            throw new IllegalArgumentException(
+                String.format("unable to serialize an instance of type[%s], field[%s] - no encoding defined",
+                    value.getClass().getTypeName(), field.getName()));
+          }
+        } else { // --- simple type ---
+          Object object = null;
+          if (repeated) {
+            object = SerializationUtil.getListValue(value, field);
+          } else {
+            object = SerializationUtil.getValue(value, field);
+          }
+          if (object != null) {
+            encodedValue = object.toString();
+          }
+        }
+        /*
+         * write out a fieldSep if present and required
+         */
+        if (index > 0 && typeEncoding.fieldSep().length > 0) {
+          encoded.append(typeEncoding.fieldSep()[0]);
+        }
+        /*
+         * if the keyValSep has been specified write out the field name followed by the
+         * keyValSep
+         */
+        if (!typeEncoding.keyValSep().isEmpty()) {
+          encoded.append(fieldName).append(typeEncoding.keyValSep());
+        }
+        /*
+         * regardless of the encoding components that were / were not specified, the
+         * encoded value must always be written
+         */
+        encoded.append(encodedValue);
+        index++;
+      } else {
+        throw new IllegalStateException(
+            String.format("failed to retrieve field property info during custom encoding of type[%s], field[%s]",
+                value.getClass().getTypeName(), fieldName));
+      }
+    }
+    /*
+     * write out the suffix if present
+     */
+    if (!typeEncoding.suffix().isEmpty()) {
+      encoded.append(typeEncoding.suffix());
+    }
+    return encoded;
+  }
+
+}

--- a/generic-messages/src/main/java/com/langtoun/messages/util/SerializationUtil.java
+++ b/generic-messages/src/main/java/com/langtoun/messages/util/SerializationUtil.java
@@ -8,6 +8,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -18,9 +19,9 @@ import javax.xml.bind.JAXBException;
 import org.apache.commons.lang3.tuple.Pair;
 
 import com.fasterxml.jackson.databind.node.ValueNode;
-import com.langtoun.messages.annotations.CustomTypeEncoding;
-import com.langtoun.messages.annotations.AwsTypeDefinition;
 import com.langtoun.messages.annotations.AwsFieldProperty;
+import com.langtoun.messages.annotations.AwsTypeDefinition;
+import com.langtoun.messages.annotations.CustomTypeEncoding;
 import com.langtoun.messages.types.CustomTypeCodec;
 
 public final class SerializationUtil {
@@ -53,7 +54,8 @@ public final class SerializationUtil {
    * annotation if it is present.
    *
    * @param object the object that is to be inspected
-   * @return an instance of the {@link AwsTypeDefinition} annotation, or {@code null)
+   * @return an instance of the {@link AwsTypeDefinition} annotation, or
+   *         {@code null)
    */
   public static AwsTypeDefinition getTypeDefinition(final Object object) {
     if (object != null) {
@@ -67,7 +69,8 @@ public final class SerializationUtil {
    * annotation if it is present.
    *
    * @param object the object that is to be inspected
-   * @return an instance of the {@link AwsTypeDefinition} annotation, or {@code null)
+   * @return an instance of the {@link AwsTypeDefinition} annotation, or
+   *         {@code null)
    */
   public static AwsTypeDefinition getTypeDefinition(final Class<?> clazz) {
     return clazz.getAnnotation(AwsTypeDefinition.class);
@@ -162,8 +165,8 @@ public final class SerializationUtil {
 
   /**
    * Retrieve a {@code Map} of field names and pairs of {@link Field} objects and
-   * {@link AwsFieldProperty} annotations for annotated fields in all superclasses of
-   * the supplied {@code Class}.
+   * {@link AwsFieldProperty} annotations for annotated fields in all superclasses
+   * of the supplied {@code Class}.
    *
    * @param clazz the class whose superclasses' annotated fields are to be
    *              retrieved
@@ -176,8 +179,8 @@ public final class SerializationUtil {
 
   /**
    * Retrieve a {@code Map} of field names and pairs of {@link Field} objects and
-   * {@link AwsFieldProperty} annotations for annotated fields in the class hierarchy
-   * of the supplied {@code Class}.
+   * {@link AwsFieldProperty} annotations for annotated fields in the class
+   * hierarchy of the supplied {@code Class}.
    *
    * @param clazz the class whose class hierarchy's annotated fields are to be
    *              retrieved
@@ -237,6 +240,20 @@ public final class SerializationUtil {
     } else {
       return field.getType();
     }
+  }
+
+  public static String consumeRequiredTokenAtStart(final String encoded, final String token, Supplier<String> exceptionMessage) {
+    if (encoded.startsWith(token)) {
+      return encoded.substring(token.length());
+    }
+    throw new IllegalStateException(exceptionMessage.get());
+  }
+
+  public static String consumeRequiredTokenAtEnd(final String encoded, final String token, Supplier<String> exceptionMessage) {
+    if (encoded.endsWith(token)) {
+      return encoded.substring(0, encoded.length() - token.length());
+    }
+    throw new IllegalStateException(exceptionMessage.get());
   }
 
   // TODO: add more Java types

--- a/generic-messages/src/test/java/com/langtoun/messages/AppTest.java
+++ b/generic-messages/src/test/java/com/langtoun/messages/AppTest.java
@@ -9,6 +9,8 @@ import com.langtoun.messages.types.gen.cars.CarEngine;
 import com.langtoun.messages.types.gen.cars.CarFeature;
 import com.langtoun.messages.types.gen.cars.ComplexCar;
 import com.langtoun.messages.types.gen.cars.ComplexCarWithFeatures;
+import com.langtoun.messages.types.gen.cars.CustomComplexCar;
+import com.langtoun.messages.types.gen.cars.CustomSimpleCar;
 import com.langtoun.messages.types.gen.cars.SimpleCar;
 
 import junit.framework.Test;
@@ -20,7 +22,7 @@ import junit.framework.TestSuite;
  */
 public class AppTest extends TestCase {
 
-  private static final ObjectMapper mapper = new ObjectMapper();
+  private static final ObjectMapper jsonMapper = new ObjectMapper();
 
   /**
    * Create the test case
@@ -43,6 +45,8 @@ public class AppTest extends TestCase {
   }
 
   public void testPlayground() throws IOException {
+    System.out.println("---- PLAYGROUND START ----");
+    System.out.println();
     System.out.println("---- SERIALIZATION ----");
     final AwsComplexType car1 = new SimpleCar("Blue", "Mazda", null);
     final AwsComplexType car2 = new ComplexCar("Blue", "Mazda", false, new CarEngine(4, "petrol"));
@@ -54,53 +58,77 @@ public class AppTest extends TestCase {
     final AwsComplexType feature = new CarFeature("Bose sound system", 1200.0);
 
     try {
-      System.out.println("serialize: car1(" + car1 + ") -> " + mapper.writeValueAsString(car1));
-      System.out.println("serialize: car2(" + car2 + ") -> " + mapper.writeValueAsString(car2));
-      System.out.println("serialize: car3(" + car3 + ") -> " + mapper.writeValueAsString(car3));
-      System.out.println("serialize: car4(" + car4 + ") -> " + mapper.writeValueAsString(car4));
-      System.out.println("serialize: engine(" + engine + ") -> " + mapper.writeValueAsString(engine));
-      System.out.println("serialize: feature(" + feature + ") -> " + mapper.writeValueAsString(feature));
+      System.out.println("serialize: car1(" + car1 + ") -> " + jsonMapper.writeValueAsString(car1));
+      System.out.println("serialize: car2(" + car2 + ") -> " + jsonMapper.writeValueAsString(car2));
+      System.out.println("serialize: car3(" + car3 + ") -> " + jsonMapper.writeValueAsString(car3));
+      System.out.println("serialize: car4(" + car4 + ") -> " + jsonMapper.writeValueAsString(car4));
+      System.out.println("serialize: engine(" + engine + ") -> " + jsonMapper.writeValueAsString(engine));
+      System.out.println("serialize: feature(" + feature + ") -> " + jsonMapper.writeValueAsString(feature));
     } catch (final IOException e) {
       e.printStackTrace();
     }
 
     System.out.println("---- DESERIALIZATION ----");
     final String jsonCar1 = "{\"colour\":\"Blue\",\"type\":\"Mazda\"}";
-    final String jsonCar2 = "{\"colour\":\"Blue\",\"type\":\"Mazda\",\"engine\":{\"cyls\":4,\"fuel\":\"petrol\"}}";
-    final String jsonCar3 = "{\"colour\":\"Blue\",\"type\":\"Mazda\",\"engine\":{\"cyls\":4,\"fuel\":\"petrol\"},\"features\":[{\"name\":\"19 inch alloys\"},{\"name\":\"Bose sound system\",\"price\":1200.0}]}";
-    final String jsonCar4 = "{\"colour\":\"Blue\",\"type\":\"Mazda\",\"engine\":{\"cyls\":4,\"fuel\":\"petrol\"},\"features\":[{\"name\":\"19 inch alloys\"},{\"price\":1200.0}]}";
-    final String jsonEngine = "{\"cyls\":6,\"fuel\":\"petrol\"}";
+    final String jsonCar2 = "{\"colour\":\"Blue\",\"type\":\"Mazda\",\"engine\":{\"cylinders\":4,\"fuelType\":\"petrol\"}}";
+    final String jsonCar3 = "{\"colour\":\"Blue\",\"type\":\"Mazda\",\"engine\":{\"cylinders\":4,\"fuelType\":\"petrol\"},\"features\":[{\"name\":\"19 inch alloys\"},{\"name\":\"Bose sound system\",\"price\":1200.0}]}";
+    final String jsonCar4 = "{\"colour\":\"Blue\",\"type\":\"Mazda\",\"engine\":{\"cylinders\":4,\"fuelType\":\"petrol\"},\"features\":[{\"name\":\"19 inch alloys\"},{\"price\":1200.0}]}";
+    final String jsonEngine = "{\"cylinders\":6,\"fuelType\":\"petrol\"}";
     final String jsonFeature = "{\"name\":\"Bose sound system\",\"price\":1200.0}";
 
     try {
-      final AwsComplexType decMessage1 = mapper.readValue(jsonCar1, SimpleCar.class);
-      final AwsComplexType decMessage2 = mapper.readValue(jsonCar2, ComplexCar.class);
-      final AwsComplexType decMessage3 = mapper.readValue(jsonCar3, ComplexCarWithFeatures.class);
-      final AwsComplexType decMessage4 = mapper.readValue(jsonEngine, CarEngine.class);
-      final AwsComplexType decMessage5 = mapper.readValue(jsonFeature, CarFeature.class);
+      final AwsComplexType deserCar1 = jsonMapper.readValue(jsonCar1, SimpleCar.class);
+      final AwsComplexType deserCar2 = jsonMapper.readValue(jsonCar2, ComplexCar.class);
+      final AwsComplexType deserCar3 = jsonMapper.readValue(jsonCar3, ComplexCarWithFeatures.class);
+      final AwsComplexType deserEngine = jsonMapper.readValue(jsonEngine, CarEngine.class);
+      final AwsComplexType deserFeature = jsonMapper.readValue(jsonFeature, CarFeature.class);
 
-      System.out.println("deserialize: jsonCar1(" + jsonCar1 + ") -> " + decMessage1);
-      System.out.println("deserialize: jsonCar2(" + jsonCar2 + ") -> " + decMessage2);
-      System.out.println("deserialize: jsonCar3(" + jsonCar3 + ") -> " + decMessage3);
-      System.out.println("deserialize: jsonEngine(" + jsonEngine + ") -> " + decMessage4);
-      System.out.println("deserialize: jsonFeature(" + jsonFeature + ") -> " + decMessage5);
+      System.out.println("deserialize: jsonCar1(" + jsonCar1 + ") -> " + deserCar1);
+      System.out.println("deserialize: jsonCar2(" + jsonCar2 + ") -> " + deserCar2);
+      System.out.println("deserialize: jsonCar3(" + jsonCar3 + ") -> " + deserCar3);
+      System.out.println("deserialize: jsonEngine(" + jsonEngine + ") -> " + deserEngine);
+      System.out.println("deserialize: jsonFeature(" + jsonFeature + ") -> " + deserFeature);
     } catch (final JsonProcessingException e) {
       e.printStackTrace();
     }
 
+    System.out.println("---- DESERIALIZATION (ERROR) ----");
     try {
-      final AwsComplexType decFailure = mapper.readValue(jsonCar4, ComplexCarWithFeatures.class);
-      System.out.println("deserialize: jsonCar4(" + jsonCar4 + ") -> " + decFailure);
+      final AwsComplexType deserFailure = jsonMapper.readValue(jsonCar4, ComplexCarWithFeatures.class);
+      System.out.println("deserialize: jsonCar4(" + jsonCar4 + ") -> " + deserFailure);
     } catch (final IllegalStateException e) {
       System.out.println("ERROR: " + e.getMessage());
     }
+
+    System.out.println("---- CUSTOM ENCODING ----");
+    final AwsComplexType customCar1 = new CustomSimpleCar("Blue", "Mazda", null);
+    final AwsComplexType customCar2 = new CustomComplexCar("Blue", "Mazda", false, new CarEngine(4, "petrol"));
+
+    System.out.println("encode: customCar1 -> " + customCar1);
+    System.out.println("encode: customCar2 -> " + customCar2);
+
+    System.out.println("---- CUSTOM DECODING ----");
+    final String encodedCar1 = "\"<<<colour=\\\"Blue\\\"|type=\\\"Mazda\\\"|rightHandDrive=null>>>\"";
+    final String encodedCar2 = "\"<<<colour=\\\"Blue\\\"|type=\\\"Mazda\\\"|rightHandDrive=false|engine=eyJjeWxpbmRlcnMiOjQsImZ1ZWxUeXBlIjoicGV0cm9sIn0>>>\"";
+
+    try {
+      final AwsComplexType decodedCar1 = jsonMapper.readValue(encodedCar1, CustomSimpleCar.class);
+      final AwsComplexType decodedCar2 = jsonMapper.readValue(encodedCar2, CustomComplexCar.class);
+
+      System.out.println("decode: encodedCar1(" + encodedCar1 + ") -> " + decodedCar1);
+      System.out.println("decode: encodedCar2(" + encodedCar2 + ") -> " + decodedCar2);
+    } catch (final Exception e) {
+      e.printStackTrace();
+    }
+
+    System.out.println("---- PLAYGROUND STOP ----");
   }
 
   public void testSerializerWithSimpleCar() throws IOException {
     final SimpleCar car = new SimpleCar("Blue", "Mazda", null);
 
     final String jsonCar = "{\"colour\":\"Blue\",\"type\":\"Mazda\"}";
-    final String carStr = mapper.writeValueAsString(car);
+    final String carStr = jsonMapper.writeValueAsString(car);
 
     assertEquals(jsonCar, carStr);
   }
@@ -108,8 +136,8 @@ public class AppTest extends TestCase {
   public void testSerializerWithComplexCar() throws IOException {
     final ComplexCar car = new ComplexCar("Blue", "Mazda", null, new CarEngine(4, "petrol"));
 
-    final String jsonCar = "{\"colour\":\"Blue\",\"type\":\"Mazda\",\"engine\":{\"cyls\":4,\"fuel\":\"petrol\"}}";
-    final String carStr = mapper.writeValueAsString(car);
+    final String jsonCar = "{\"colour\":\"Blue\",\"type\":\"Mazda\",\"engine\":{\"cylinders\":4,\"fuelType\":\"petrol\"}}";
+    final String carStr = jsonMapper.writeValueAsString(car);
 
     assertEquals(jsonCar, carStr);
   }
@@ -117,8 +145,8 @@ public class AppTest extends TestCase {
   public void testSerializerWithComplexCarAndRequiredNull() throws IOException {
     final ComplexCar car = new ComplexCar("Blue", "Mazda", null, new CarEngine(null, "petrol"));
 
-    final String jsonCar = "{\"colour\":\"Blue\",\"type\":\"Mazda\",\"engine\":{\"cyls\":null,\"fuel\":\"petrol\"}}";
-    final String carStr = mapper.writeValueAsString(car);
+    final String jsonCar = "{\"colour\":\"Blue\",\"type\":\"Mazda\",\"engine\":{\"cylinders\":null,\"fuelType\":\"petrol\"}}";
+    final String carStr = jsonMapper.writeValueAsString(car);
 
     assertEquals(jsonCar, carStr);
   }
@@ -126,8 +154,8 @@ public class AppTest extends TestCase {
   public void testSerializerWithComplexCarAndOptionalNull() throws IOException {
     final ComplexCar car = new ComplexCar("Blue", "Mazda", null, new CarEngine(4, null));
 
-    final String jsonCar = "{\"colour\":\"Blue\",\"type\":\"Mazda\",\"engine\":{\"cyls\":4}}";
-    final String carStr = mapper.writeValueAsString(car);
+    final String jsonCar = "{\"colour\":\"Blue\",\"type\":\"Mazda\",\"engine\":{\"cylinders\":4}}";
+    final String carStr = jsonMapper.writeValueAsString(car);
 
     assertEquals(jsonCar, carStr);
   }
@@ -135,8 +163,8 @@ public class AppTest extends TestCase {
   public void testSerializerWithComplexCarAndNoFeatures() throws IOException {
     final ComplexCarWithFeatures car = new ComplexCarWithFeatures("Blue", "Mazda", null, new CarEngine(4, null));
 
-    final String jsonCar = "{\"colour\":\"Blue\",\"type\":\"Mazda\",\"engine\":{\"cyls\":4},\"features\":[]}";
-    final String carStr = mapper.writeValueAsString(car);
+    final String jsonCar = "{\"colour\":\"Blue\",\"type\":\"Mazda\",\"engine\":{\"cylinders\":4},\"features\":[]}";
+    final String carStr = jsonMapper.writeValueAsString(car);
 
     assertEquals(jsonCar, carStr);
   }
@@ -145,8 +173,8 @@ public class AppTest extends TestCase {
     final ComplexCarWithFeatures car = new ComplexCarWithFeatures("Blue", "Mazda", null, new CarEngine(4, null));
     car.addFeature(new CarFeature("19 inch alloys", 1000.0));
 
-    final String jsonCar = "{\"colour\":\"Blue\",\"type\":\"Mazda\",\"engine\":{\"cyls\":4},\"features\":[{\"name\":\"19 inch alloys\",\"price\":1000.0}]}";
-    final String carStr = mapper.writeValueAsString(car);
+    final String jsonCar = "{\"colour\":\"Blue\",\"type\":\"Mazda\",\"engine\":{\"cylinders\":4},\"features\":[{\"name\":\"19 inch alloys\",\"price\":1000.0}]}";
+    final String carStr = jsonMapper.writeValueAsString(car);
 
     assertEquals(jsonCar, carStr);
   }
@@ -155,8 +183,8 @@ public class AppTest extends TestCase {
     final ComplexCarWithFeatures car = new ComplexCarWithFeatures("Blue", "Mazda", null, new CarEngine(4, null));
     car.addFeature(new CarFeature("19 inch alloys", null));
 
-    final String jsonCar = "{\"colour\":\"Blue\",\"type\":\"Mazda\",\"engine\":{\"cyls\":4},\"features\":[{\"name\":\"19 inch alloys\"}]}";
-    final String carStr = mapper.writeValueAsString(car);
+    final String jsonCar = "{\"colour\":\"Blue\",\"type\":\"Mazda\",\"engine\":{\"cylinders\":4},\"features\":[{\"name\":\"19 inch alloys\"}]}";
+    final String carStr = jsonMapper.writeValueAsString(car);
 
     assertEquals(jsonCar, carStr);
   }
@@ -164,47 +192,47 @@ public class AppTest extends TestCase {
   public void testDeserializerWithSimpleCar() throws IOException {
     final String jsonCar = "{\"colour\":\"Blue\",\"type\":\"Mazda\"}";
     final String carStr = "Blue Mazda";
-    final AwsComplexType car = mapper.readValue(jsonCar, SimpleCar.class);
+    final AwsComplexType car = jsonMapper.readValue(jsonCar, SimpleCar.class);
 
     assertEquals(carStr, car.toString());
   }
 
   public void testDeserializerWithSimpleCarLHD() throws IOException {
-    final String jsonCar = "{\"colour\":\"Blue\",\"type\":\"Mazda\",\"rhs\":false}";
+    final String jsonCar = "{\"colour\":\"Blue\",\"type\":\"Mazda\",\"rightHandDrive\":false}";
     final String carStr = "Blue Mazda (lhd)";
-    final AwsComplexType car = mapper.readValue(jsonCar, SimpleCar.class);
+    final AwsComplexType car = jsonMapper.readValue(jsonCar, SimpleCar.class);
 
     assertEquals(carStr, car.toString());
   }
 
   public void testDeserializerWithSimpleCarRHD() throws IOException {
-    final String jsonCar = "{\"colour\":\"Blue\",\"type\":\"Mazda\",\"rhs\":true}";
+    final String jsonCar = "{\"colour\":\"Blue\",\"type\":\"Mazda\",\"rightHandDrive\":true}";
     final String carStr = "Blue Mazda (rhd)";
-    final AwsComplexType car = mapper.readValue(jsonCar, SimpleCar.class);
+    final AwsComplexType car = jsonMapper.readValue(jsonCar, SimpleCar.class);
 
     assertEquals(carStr, car.toString());
   }
 
   public void testDeserializerWithComplexCar() throws IOException {
-    final String jsonCar = "{\"colour\":\"Blue\",\"type\":\"Mazda\",\"engine\":{\"cyls\":4,\"fuel\":\"petrol\"}}";
+    final String jsonCar = "{\"colour\":\"Blue\",\"type\":\"Mazda\",\"engine\":{\"cylinders\":4,\"fuelType\":\"petrol\"}}";
     final String carStr = "Blue Mazda [4 cyl petrol]";
-    final AwsComplexType car = mapper.readValue(jsonCar, ComplexCar.class);
+    final AwsComplexType car = jsonMapper.readValue(jsonCar, ComplexCar.class);
 
     assertEquals(carStr, car.toString());
   }
 
   public void testDeserializerWithComplexCarLHD() throws IOException {
-    final String jsonCar = "{\"colour\":\"Blue\",\"type\":\"Mazda\",\"rhs\":false,\"engine\":{\"cyls\":4,\"fuel\":\"petrol\"}}";
+    final String jsonCar = "{\"colour\":\"Blue\",\"type\":\"Mazda\",\"rightHandDrive\":false,\"engine\":{\"cylinders\":4,\"fuelType\":\"petrol\"}}";
     final String carStr = "Blue Mazda (lhd) [4 cyl petrol]";
-    final AwsComplexType car = mapper.readValue(jsonCar, ComplexCar.class);
+    final AwsComplexType car = jsonMapper.readValue(jsonCar, ComplexCar.class);
 
     assertEquals(carStr, car.toString());
   }
 
   public void testDeserializerWithComplexCarRHD() throws IOException {
-    final String jsonCar = "{\"colour\":\"Blue\",\"type\":\"Mazda\",\"rhs\":true,\"engine\":{\"cyls\":4,\"fuel\":\"petrol\"}}";
+    final String jsonCar = "{\"colour\":\"Blue\",\"type\":\"Mazda\",\"rightHandDrive\":true,\"engine\":{\"cylinders\":4,\"fuelType\":\"petrol\"}}";
     final String carStr = "Blue Mazda (rhd) [4 cyl petrol]";
-    final AwsComplexType car = mapper.readValue(jsonCar, ComplexCar.class);
+    final AwsComplexType car = jsonMapper.readValue(jsonCar, ComplexCar.class);
 
     assertEquals(carStr, car.toString());
   }

--- a/generic-messages/src/test/java/com/langtoun/messages/types/gen/cars/CarEngine.java
+++ b/generic-messages/src/test/java/com/langtoun/messages/types/gen/cars/CarEngine.java
@@ -2,9 +2,9 @@ package com.langtoun.messages.types.gen.cars;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.langtoun.messages.annotations.FieldOrder;
-import com.langtoun.messages.annotations.AwsTypeDefinition;
 import com.langtoun.messages.annotations.AwsFieldProperty;
+import com.langtoun.messages.annotations.AwsTypeDefinition;
+import com.langtoun.messages.annotations.FieldOrder;
 import com.langtoun.messages.generic.AwsComplexTypeJsonDeserializer;
 import com.langtoun.messages.generic.AwsComplexTypeJsonSerializer;
 import com.langtoun.messages.types.AwsComplexType;
@@ -24,10 +24,10 @@ import com.langtoun.messages.types.AwsComplexType;
 // @Format-On
 public class CarEngine extends AwsComplexType {
 
-  @AwsFieldProperty(required = true, jsonName = "cyls")
+  @AwsFieldProperty(required = true)
   private Integer cylinders;
 
-  @AwsFieldProperty(jsonName = "fuel")
+  @AwsFieldProperty
   private String fuelType;
 
   public CarEngine() {

--- a/generic-messages/src/test/java/com/langtoun/messages/types/gen/cars/CarFeature.java
+++ b/generic-messages/src/test/java/com/langtoun/messages/types/gen/cars/CarFeature.java
@@ -2,9 +2,9 @@ package com.langtoun.messages.types.gen.cars;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.langtoun.messages.annotations.FieldOrder;
-import com.langtoun.messages.annotations.AwsTypeDefinition;
 import com.langtoun.messages.annotations.AwsFieldProperty;
+import com.langtoun.messages.annotations.AwsTypeDefinition;
+import com.langtoun.messages.annotations.FieldOrder;
 import com.langtoun.messages.generic.AwsComplexTypeJsonDeserializer;
 import com.langtoun.messages.generic.AwsComplexTypeJsonSerializer;
 import com.langtoun.messages.types.AwsComplexType;
@@ -23,10 +23,10 @@ import com.langtoun.messages.types.AwsComplexType;
 // @Format-On
 public class CarFeature extends AwsComplexType {
 
-  @AwsFieldProperty(required = true, jsonName = "name")
+  @AwsFieldProperty(required = true)
   private String name;
 
-  @AwsFieldProperty(jsonName = "price")
+  @AwsFieldProperty
   private Double price;
 
   public CarFeature() {

--- a/generic-messages/src/test/java/com/langtoun/messages/types/gen/cars/ComplexCar.java
+++ b/generic-messages/src/test/java/com/langtoun/messages/types/gen/cars/ComplexCar.java
@@ -2,9 +2,9 @@ package com.langtoun.messages.types.gen.cars;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.langtoun.messages.annotations.FieldOrder;
-import com.langtoun.messages.annotations.AwsTypeDefinition;
 import com.langtoun.messages.annotations.AwsFieldProperty;
+import com.langtoun.messages.annotations.AwsTypeDefinition;
+import com.langtoun.messages.annotations.FieldOrder;
 import com.langtoun.messages.generic.AwsComplexTypeJsonDeserializer;
 import com.langtoun.messages.generic.AwsComplexTypeJsonSerializer;
 
@@ -23,7 +23,7 @@ import com.langtoun.messages.generic.AwsComplexTypeJsonSerializer;
 // @Format-On
 public class ComplexCar extends SimpleCar {
 
-  @AwsFieldProperty(required = true, jsonName = "engine")
+  @AwsFieldProperty(required = true)
   private CarEngine engine;
 
   public ComplexCar() {

--- a/generic-messages/src/test/java/com/langtoun/messages/types/gen/cars/ComplexCarWithFeatures.java
+++ b/generic-messages/src/test/java/com/langtoun/messages/types/gen/cars/ComplexCarWithFeatures.java
@@ -5,9 +5,9 @@ import java.util.List;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.langtoun.messages.annotations.FieldOrder;
-import com.langtoun.messages.annotations.AwsTypeDefinition;
 import com.langtoun.messages.annotations.AwsFieldProperty;
+import com.langtoun.messages.annotations.AwsTypeDefinition;
+import com.langtoun.messages.annotations.FieldOrder;
 import com.langtoun.messages.generic.AwsComplexTypeJsonDeserializer;
 import com.langtoun.messages.generic.AwsComplexTypeJsonSerializer;
 
@@ -26,7 +26,7 @@ import com.langtoun.messages.generic.AwsComplexTypeJsonSerializer;
 // @Format-On
 public class ComplexCarWithFeatures extends ComplexCar {
 
-  @AwsFieldProperty(required = true, jsonName = "features")
+  @AwsFieldProperty(required = true)
   private final List<CarFeature> features = new ArrayList<>();
 
   public ComplexCarWithFeatures() {
@@ -49,7 +49,7 @@ public class ComplexCarWithFeatures extends ComplexCar {
 
   @Override
   public String toString() {
-    return super.toString() + " with " + features + "]";
+    return super.toString() + " with " + features;
   }
 
 }

--- a/generic-messages/src/test/java/com/langtoun/messages/types/gen/cars/CustomComplexCar.java
+++ b/generic-messages/src/test/java/com/langtoun/messages/types/gen/cars/CustomComplexCar.java
@@ -2,12 +2,12 @@ package com.langtoun.messages.types.gen.cars;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.langtoun.messages.annotations.AwsFieldProperty;
+import com.langtoun.messages.annotations.AwsTypeDefinition;
 import com.langtoun.messages.annotations.CustomTypeEncoding;
 import com.langtoun.messages.annotations.FieldOrder;
-import com.langtoun.messages.annotations.AwsTypeDefinition;
-import com.langtoun.messages.annotations.AwsFieldProperty;
 import com.langtoun.messages.generic.AwsComplexTypeJsonDeserializer;
-import com.langtoun.messages.generic.AwsComplexTypeJsonSerializer;
+import com.langtoun.messages.generic.AwsCustomEncodingSerializer;
 import com.langtoun.messages.types.FieldEncodingType;
 
 /**
@@ -15,7 +15,7 @@ import com.langtoun.messages.types.FieldEncodingType;
  * annotated with {@link AwsTypeDefinition} and {@link AwsFieldProperty}.
  * 
  */
-@JsonSerialize(using = AwsComplexTypeJsonSerializer.class, as = CustomComplexCar.class)
+@JsonSerialize(using = AwsCustomEncodingSerializer.class, as = CustomComplexCar.class)
 @JsonDeserialize(using = AwsComplexTypeJsonDeserializer.class, as = CustomComplexCar.class)
 // @Format-Off
 @AwsTypeDefinition(
@@ -27,9 +27,9 @@ import com.langtoun.messages.types.FieldEncodingType;
   )
 )
 // @Format-On
-public class CustomComplexCar extends SimpleCar {
+public class CustomComplexCar extends CustomSimpleCar {
 
-  @AwsFieldProperty(required = true, originalName = "engine", encoding = FieldEncodingType.JSON)
+  @AwsFieldProperty(required = true, encoding = FieldEncodingType.BASE64)
   private CarEngine engine;
 
   public CustomComplexCar() {
@@ -47,7 +47,7 @@ public class CustomComplexCar extends SimpleCar {
 
   @Override
   public String toString() {
-    return AwsComplexTypeJsonSerializer.serializeCustomEncoding(this);
+    return AwsCustomEncodingSerializer.serializeCustomEncoding(this);
   }
 
 }

--- a/generic-messages/src/test/java/com/langtoun/messages/types/gen/cars/CustomSimpleCar.java
+++ b/generic-messages/src/test/java/com/langtoun/messages/types/gen/cars/CustomSimpleCar.java
@@ -2,12 +2,12 @@ package com.langtoun.messages.types.gen.cars;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.langtoun.messages.annotations.AwsFieldProperty;
+import com.langtoun.messages.annotations.AwsTypeDefinition;
 import com.langtoun.messages.annotations.CustomTypeEncoding;
 import com.langtoun.messages.annotations.FieldOrder;
-import com.langtoun.messages.annotations.AwsTypeDefinition;
-import com.langtoun.messages.annotations.AwsFieldProperty;
 import com.langtoun.messages.generic.AwsComplexTypeJsonDeserializer;
-import com.langtoun.messages.generic.AwsComplexTypeJsonSerializer;
+import com.langtoun.messages.generic.AwsCustomEncodingSerializer;
 import com.langtoun.messages.types.AwsComplexType;
 import com.langtoun.messages.types.FieldEncodingType;
 
@@ -16,7 +16,7 @@ import com.langtoun.messages.types.FieldEncodingType;
  * annotated with {@link AwsTypeDefinition} and {@link AwsFieldProperty}.
  *
  */
-@JsonSerialize(using = AwsComplexTypeJsonSerializer.class, as = CustomSimpleCar.class)
+@JsonSerialize(using = AwsCustomEncodingSerializer.class, as = CustomSimpleCar.class)
 @JsonDeserialize(using = AwsComplexTypeJsonDeserializer.class, as = CustomSimpleCar.class)
 // @Format-Off
 @AwsTypeDefinition(
@@ -30,13 +30,13 @@ import com.langtoun.messages.types.FieldEncodingType;
 // @Format-On
 public class CustomSimpleCar extends AwsComplexType {
 
-  @AwsFieldProperty(required = true, originalName = "colour", encoding = FieldEncodingType.JSON)
+  @AwsFieldProperty(required = true, encoding = FieldEncodingType.JSON_URLENCODED)
   private String colour;
 
-  @AwsFieldProperty(required = true, originalName = "type", encoding = FieldEncodingType.XML)
+  @AwsFieldProperty(required = true, encoding = FieldEncodingType.JSON_URLENCODED)
   private String type;
 
-  @AwsFieldProperty(originalName = "right_hand_drive", encoding = FieldEncodingType.XML_URLENCODED)
+  @AwsFieldProperty(encoding = FieldEncodingType.JSON_URLENCODED)
   private Boolean rightHandDrive;
 
   public CustomSimpleCar() {
@@ -63,7 +63,7 @@ public class CustomSimpleCar extends AwsComplexType {
 
   @Override
   public String toString() {
-    return AwsComplexTypeJsonSerializer.serializeCustomEncoding(this);
+    return AwsCustomEncodingSerializer.serializeCustomEncoding(this);
   }
 
 }

--- a/generic-messages/src/test/java/com/langtoun/messages/types/gen/cars/SimpleCar.java
+++ b/generic-messages/src/test/java/com/langtoun/messages/types/gen/cars/SimpleCar.java
@@ -2,9 +2,9 @@ package com.langtoun.messages.types.gen.cars;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.langtoun.messages.annotations.FieldOrder;
-import com.langtoun.messages.annotations.AwsTypeDefinition;
 import com.langtoun.messages.annotations.AwsFieldProperty;
+import com.langtoun.messages.annotations.AwsTypeDefinition;
+import com.langtoun.messages.annotations.FieldOrder;
 import com.langtoun.messages.generic.AwsComplexTypeJsonDeserializer;
 import com.langtoun.messages.generic.AwsComplexTypeJsonSerializer;
 import com.langtoun.messages.types.AwsComplexType;
@@ -24,13 +24,13 @@ import com.langtoun.messages.types.AwsComplexType;
 // @Format-On
 public class SimpleCar extends AwsComplexType {
 
-  @AwsFieldProperty(required = true, jsonName = "colour")
+  @AwsFieldProperty(required = true)
   private String colour;
 
-  @AwsFieldProperty(required = true, jsonName = "type")
+  @AwsFieldProperty(required = true)
   private String type;
 
-  @AwsFieldProperty(jsonName = "rhs")
+  @AwsFieldProperty
   private Boolean rightHandDrive;
 
   public SimpleCar() {


### PR DESCRIPTION
The customer codecs come in two flavours: delimiter based and GQL. The delimiter based codec allows the prefix, suffix, field separator, and key/value separator to be specified as well as respecting the individual field encodings specified in the field annotation. The GQL codec is standalone with no further configuration parameters from either the AwsTypeDefinition or AwsFieldProperty annotations.