### PR TITLE
Performance improvements

### DIFF
--- a/generic-messages/src/main/java/com/langtoun/messages/generic/AwsComplexTypeJsonDeserializer.java
+++ b/generic-messages/src/main/java/com/langtoun/messages/generic/AwsComplexTypeJsonDeserializer.java
@@ -10,6 +10,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
@@ -40,7 +41,7 @@ import com.langtoun.messages.annotations.CustomTypeEncoding;
 import com.langtoun.messages.types.AwsComplexType;
 import com.langtoun.messages.types.CustomTypeCodec;
 import com.langtoun.messages.types.FieldEncodingType;
-import com.langtoun.messages.util.SerializationUtil;
+import com.langtoun.messages.util.SerializationHelper;
 
 /**
  * JSON deserializer for types that extend the {@link AwsComplexType} base
@@ -80,12 +81,15 @@ public class AwsComplexTypeJsonDeserializer extends JsonDeserializer<AwsComplexT
     /*
      * check that the type is annotated with TypeDefinition
      */
-    final AwsTypeDefinition typeDefinition = SerializationUtil.getTypeDefinition(javaType.getRawClass());
+    final AwsTypeDefinition typeDefinition = SerializationHelper.getTypeDefinition(javaType.getRawClass());
     if (typeDefinition != null) {
       try {
         final JsonNode rootNode = parser.getCodec().readTree(parser);
         final AwsComplexType value = (AwsComplexType) javaType.getRawClass().getConstructor().newInstance();
-        return deserializeComplexType(value, rootNode, typeDefinition);
+        if (SerializationHelper.usesCustomTypeEncoding(javaType.getRawClass())) {
+          return deserializeCustomEncoding(value, rootNode, typeDefinition);
+        }
+        return deserializeComplexType(value, rootNode, typeDefinition, "/", "  ");
       } catch (IllegalAccessException | InstantiationException | InvocationTargetException | NoSuchMethodException
           | SecurityException e) {
         throw new IllegalArgumentException(String.format("unable to deserialize an instance of type[%s]", javaType.getTypeName()),
@@ -103,14 +107,6 @@ public class AwsComplexTypeJsonDeserializer extends JsonDeserializer<AwsComplexT
       throw new IllegalArgumentException(
           String.format("unable to deserialize an instance of type[%s] from input[%s]", valueType.getTypeName(), json), e);
     }
-  }
-
-  private static AwsComplexType deserializeComplexType(final AwsComplexType value, final JsonNode rootNode,
-      final AwsTypeDefinition typeDefinition) {
-    if (SerializationUtil.usesCustomTypeEncoding(typeDefinition.encoding())) {
-      return deserializeCustomEncoding(value, rootNode, typeDefinition);
-    }
-    return deserializeComplexType(value, rootNode, typeDefinition, "/", "  ");
   }
 
   private static AwsComplexType deserializeCustomEncoding(final AwsComplexType value, final JsonNode rootNode,
@@ -136,15 +132,17 @@ public class AwsComplexTypeJsonDeserializer extends JsonDeserializer<AwsComplexT
   private static AwsComplexType deserializeComplexType(final AwsComplexType value, final JsonNode rootNode,
       final AwsTypeDefinition typeDefinition, final String nodePath, final String indent) {
     /*
-     * retrieve the fields annotated with TypeProperty and compute the field order
+     * retrieve the fields annotated with TypeProperty
      */
-    final Map<String, Pair<Field, AwsFieldProperty>> fieldProperties = SerializationUtil
-        .getHierarchyFieldsWithTypeProperty(value.getClass());
-    final String[] fieldOrder = SerializationUtil.computeFieldOrder(typeDefinition, fieldProperties);
+    final Map<String, Pair<Field, AwsFieldProperty>> fieldProperties = SerializationHelper.computeFieldProperties(value.getClass());
     /*
-     * iterate over the fields to be deserialized
+     * iterate over the fields to be deserialized (do this in the order they appear
+     * in the stream - validation is a separate step that comes later)
      */
-    for (final String fieldName : fieldOrder) {
+    final Iterator<Entry<String, JsonNode>> jsonIter = rootNode.fields();
+    while (jsonIter.hasNext()) {
+      Entry<String, JsonNode> jsonField = jsonIter.next();
+      final String fieldName = jsonField.getKey();
       final Pair<Field, AwsFieldProperty> fieldProperty = fieldProperties.get(fieldName);
       if (fieldProperty != null) {
         final Field field = fieldProperty.getKey();
@@ -154,12 +152,15 @@ public class AwsComplexTypeJsonDeserializer extends JsonDeserializer<AwsComplexT
          * objects as the deserializer walks the node tree
          */
         final Class<?> fieldType = field.getType();
-        final JsonNode jsonField = rootNode.findValue(fieldName);
-        if (jsonField != null) {
+        final JsonNode jsonNode = jsonField.getValue();
+        if (jsonNode != null) {
           if (List.class.isAssignableFrom(fieldType)) {
-            if (jsonField instanceof ArrayNode) {
+            /*
+             * the field indicates that it is a List type so we need to find an ArrayNode
+             */
+            if (jsonNode instanceof ArrayNode) {
               System.out.println(indent + fieldName + "[]");
-              SerializationUtil.setValue(value, readArrayValues((ArrayNode) jsonField, field, property, nodePath, indent + "  "),
+              SerializationHelper.setValue(value, readArrayValues((ArrayNode) jsonNode, field, property, nodePath, indent + "  "),
                   field);
             } else {
               throw new IllegalStateException(String.format("%s%s: failed to process list property for type[%s], field[%s]",
@@ -169,18 +170,12 @@ public class AwsComplexTypeJsonDeserializer extends JsonDeserializer<AwsComplexT
             /*
              * deserialize the scalar value (may be simple or complex)
              */
-            SerializationUtil.setValue(value, readScalarValue(jsonField, fieldName, field, nodePath, indent), field);
+            SerializationHelper.setValue(value, readScalarValue(jsonNode, fieldName, field, nodePath, indent), field);
           }
-        } else if (property.required()) {
-          System.out.println(indent + fieldName + " - required (not present)");
-          throw new IllegalStateException(String.format("%s%s: missing required property for type[%s], field[%s]", nodePath,
-              fieldName, value.getClass().getTypeName(), field.getName()));
-        } else {
-          System.out.println(indent + fieldName + " - optional (not present)");
         }
       } else {
         throw new IllegalStateException(
-            String.format("failed to retrieve field property info during serialization of type[%s], field[%s]",
+            String.format("failed to retrieve field property info during deserialization of type[%s], field[%s]",
                 value.getClass().getTypeName(), fieldName));
       }
     }
@@ -213,7 +208,7 @@ public class AwsComplexTypeJsonDeserializer extends JsonDeserializer<AwsComplexT
     } else if (node instanceof ValueNode) {
       System.out.println(indent + fieldName);
       final ValueNode valueNode = (ValueNode) node;
-      return SerializationUtil.coerceFromNode(valueNode, fieldName);
+      return SerializationHelper.coerceFromNode(valueNode, fieldName);
     } else {
       throw new IllegalStateException(
           String.format("%s%s: failed to process scalar property for type[%s], field[%s]", nodePath, fieldName));
@@ -222,12 +217,12 @@ public class AwsComplexTypeJsonDeserializer extends JsonDeserializer<AwsComplexT
 
   private static Object readComplexValue(final ObjectNode objectNode, final String fieldName, Field field, final String nodePath,
       final String indent) {
-    final Class<?> fieldType = SerializationUtil.getValueType(field);
+    final Class<?> fieldType = SerializationHelper.getValueType(field);
     if (AwsComplexType.class.isAssignableFrom(fieldType)) {
       try {
         final AwsComplexType value = (AwsComplexType) fieldType.getConstructor().newInstance();
-        return deserializeComplexType(value, objectNode, SerializationUtil.getTypeDefinition(fieldType), nodePath + fieldName + "/",
-            indent + "  ");
+        return deserializeComplexType(value, objectNode, SerializationHelper.getTypeDefinition(fieldType),
+            nodePath + fieldName + "/", indent + "  ");
       } catch (IllegalAccessException | InstantiationException | InvocationTargetException | NoSuchMethodException
           | SecurityException e) {
         throw new IllegalStateException(
@@ -250,7 +245,7 @@ public class AwsComplexTypeJsonDeserializer extends JsonDeserializer<AwsComplexT
      * check and consume the prefix
      */
     if (!typeEncoding.prefix().isEmpty()) {
-      remaining = SerializationUtil.consumeRequiredTokenAtStart(remaining, typeEncoding.prefix(), () -> {
+      remaining = SerializationHelper.consumeRequiredTokenAtStart(remaining, typeEncoding.prefix(), () -> {
         return String.format("encoded[%s] must have prefix[%s]", value.getClass().getTypeName(), typeEncoding.prefix());
       });
     }
@@ -258,21 +253,20 @@ public class AwsComplexTypeJsonDeserializer extends JsonDeserializer<AwsComplexT
      * check and consume the suffix
      */
     if (!typeEncoding.suffix().isEmpty()) {
-      remaining = SerializationUtil.consumeRequiredTokenAtEnd(remaining, typeEncoding.suffix(), () -> {
+      remaining = SerializationHelper.consumeRequiredTokenAtEnd(remaining, typeEncoding.suffix(), () -> {
         return String.format("encoded[%s] must have suffix[%s]", value.getClass().getTypeName(), typeEncoding.suffix());
       });
     }
     /*
      * decode each field in the order specified in the computed field order
      */
-    final Map<String, Pair<Field, AwsFieldProperty>> fieldProperties = SerializationUtil
-        .getHierarchyFieldsWithTypeProperty(value.getClass());
-    final String[] fieldOrder = SerializationUtil.computeFieldOrder(typeDefinition, fieldProperties);
+    final Map<String, Pair<Field, AwsFieldProperty>> fieldProperties = SerializationHelper.computeFieldProperties(value.getClass());
+    final String[] fieldOrder = SerializationHelper.computeFieldOrder(typeDefinition, fieldProperties);
     /*
      * split the remaining encoded message into encoded fields (the number of fields
      * must match the number of entries in the computed field order)
      */
-    final String[] encodedFields = remaining.split(SerializationUtil.createSeparatorPattern(typeEncoding.fieldSep()));
+    final String[] encodedFields = remaining.split(SerializationHelper.createSeparatorPattern(typeEncoding.fieldSep()));
     /*
      * create a map of field name and encoded field value using the field order if
      * no key value separator is specified
@@ -333,39 +327,40 @@ public class AwsComplexTypeJsonDeserializer extends JsonDeserializer<AwsComplexT
             }
             if (fieldEncoding != FieldEncodingType.UNKNOWN) {
               if (fieldEncoding == FieldEncodingType.XML || fieldEncoding == FieldEncodingType.XML_URLENCODED) {
-                final JAXBContext jaxbContext = SerializationUtil.getJaxbContextFor((Class<?>) (repeated ? List.class : fieldType));
+                final JAXBContext jaxbContext = SerializationHelper
+                    .getJaxbContextFor((Class<?>) (repeated ? List.class : fieldType));
                 final InputStream xmlStream = new java.io.ByteArrayInputStream(encodedField.getBytes());
                 final Unmarshaller unmarshaller = jaxbContext.createUnmarshaller();
-                SerializationUtil.setValue(value, unmarshaller.unmarshal(xmlStream), field);
+                SerializationHelper.setValue(value, unmarshaller.unmarshal(xmlStream), field);
                 // SerializationUtil.setValue(value,
                 // com.avaloq.front.common.util.SafeXMLUtils.safeUnmarshal(xmlStream,
                 // jaxbContext), field);
               } else if (fieldEncoding == FieldEncodingType.JSON || fieldEncoding == FieldEncodingType.JSON_URLENCODED) {
-                SerializationUtil.setValue(value,
+                SerializationHelper.setValue(value,
                     objectMapper.readValue(encodedField, (Class<?>) (repeated ? List.class : fieldType)), field);
               } else if (fieldEncoding == FieldEncodingType.BASE64) {
                 final Base64 base64Url = new Base64(true);
                 encodedField = new String(base64Url.decode(encodedField));
-                SerializationUtil.setValue(value,
+                SerializationHelper.setValue(value,
                     objectMapper.readValue(encodedField, (Class<?>) (repeated ? List.class : fieldType)), field);
               }
             } else {
               // Try to dynamically infer the encoding from the contents
               if (encodedField.startsWith("{") || encodedField.startsWith("[")) {
-                SerializationUtil.setValue(value,
+                SerializationHelper.setValue(value,
                     objectMapper.readValue(encodedField, (Class<?>) (repeated ? List.class : fieldType)), field);
               } else if (encodedField.startsWith("<")) {
-                javax.xml.bind.JAXBContext jaxbContext = SerializationUtil
+                javax.xml.bind.JAXBContext jaxbContext = SerializationHelper
                     .getJaxbContextFor((Class<?>) (repeated ? List.class : fieldType));
                 java.io.InputStream xmlStream = new java.io.ByteArrayInputStream(encodedField.getBytes());
                 final Unmarshaller unmarshaller = jaxbContext.createUnmarshaller();
-                SerializationUtil.setValue(value, unmarshaller.unmarshal(xmlStream), field);
+                SerializationHelper.setValue(value, unmarshaller.unmarshal(xmlStream), field);
                 // SerializationUtil.setValue(value,
                 // com.avaloq.front.common.util.SafeXMLUtils.safeUnmarshal(xmlStream,
                 // jaxbContext), field);
               } else {
                 if (!AwsComplexType.class.isAssignableFrom(fieldType)) {
-                  SerializationUtil.setValue(value, SerializationUtil.coerceFromString(encodedField, fieldType), field);
+                  SerializationHelper.setValue(value, SerializationHelper.coerceValueFromString(encodedField, fieldType), field);
                 } else {
                   throw new IllegalArgumentException(
                       String.format("unable to deserialize an instance of type[%s] from encoded field[%s]",
@@ -386,7 +381,7 @@ public class AwsComplexTypeJsonDeserializer extends JsonDeserializer<AwsComplexT
         }
       } else {
         throw new IllegalStateException(
-            String.format("failed to retrieve field property info during serialization of type[%s], field[%s]",
+            String.format("failed to retrieve field property info during deserialization of type[%s], field[%s]",
                 value.getClass().getTypeName(), fieldName));
       }
 

--- a/generic-messages/src/main/java/com/langtoun/messages/util/SerializationHelper.java
+++ b/generic-messages/src/main/java/com/langtoun/messages/util/SerializationHelper.java
@@ -24,11 +24,15 @@ import com.langtoun.messages.annotations.AwsTypeDefinition;
 import com.langtoun.messages.annotations.CustomTypeEncoding;
 import com.langtoun.messages.types.CustomTypeCodec;
 
-public final class SerializationUtil {
+public final class SerializationHelper {
 
   private static final Map<Class<?>, JAXBContext> jaxbContexts = new HashMap<>();
 
-  private SerializationUtil() {
+  private static final Map<Class<?>, Map<String, Pair<Field, AwsFieldProperty>>> fieldsWithPropertyAnnotationMap = new HashMap<>();
+
+  private static final Map<Class<?>, Boolean> usesCustomTypeEncodingMap = new HashMap<>();
+
+  private SerializationHelper() {
     // static utility methods
   }
 
@@ -78,15 +82,23 @@ public final class SerializationUtil {
 
   /**
    * Given a {@link CustomTypeEncoding} annotation, determine whether or not the
-   * type has been configured to use a custom type encoding.
+   * type has been configured to use a custom type encoding. The result is
+   * computed only if it hasn't already been cached.
    * 
-   * @param typeEncoding the type encoding annotation
+   * @param clazz the class for which the result is to be computed
    * @return {@code true} if the annotation indicates a custom type encoding,
    *         otherwise {@code false}
    */
-  public static boolean usesCustomTypeEncoding(final CustomTypeEncoding typeEncoding) {
-    return !typeEncoding.prefix().isEmpty() || !typeEncoding.suffix().isEmpty() || !typeEncoding.keyValSep().isEmpty()
-        || typeEncoding.codec() != CustomTypeCodec.NONE;
+  public static boolean usesCustomTypeEncoding(final Class<?> clazz) {
+    return usesCustomTypeEncodingMap.computeIfAbsent(clazz, c -> {
+      final AwsTypeDefinition typeDefinition = c.getAnnotation(AwsTypeDefinition.class);
+      if (typeDefinition != null) {
+        final CustomTypeEncoding typeEncoding = typeDefinition.encoding();
+        return !typeEncoding.prefix().isEmpty() || !typeEncoding.suffix().isEmpty() || !typeEncoding.keyValSep().isEmpty()
+            || typeEncoding.codec() != CustomTypeCodec.NONE;
+      }
+      return false;
+    });
   }
 
   /**
@@ -180,15 +192,17 @@ public final class SerializationUtil {
   /**
    * Retrieve a {@code Map} of field names and pairs of {@link Field} objects and
    * {@link AwsFieldProperty} annotations for annotated fields in the class
-   * hierarchy of the supplied {@code Class}.
+   * hierarchy of the supplied {@code Class}. The result is computed only if it
+   * hasn't already been cached.
    *
    * @param clazz the class whose class hierarchy's annotated fields are to be
-   *              retrieved
+   *              computed
    * @return a map of pairs of {@link Field} objects and {@link AwsFieldProperty}
    *         annotations
    */
-  public static Map<String, Pair<Field, AwsFieldProperty>> getHierarchyFieldsWithTypeProperty(final Class<?> clazz) {
-    return getDeclaredFieldsWithAnnotation(getClassHierarchy(clazz).stream().flatMap(c -> Stream.of(c.getDeclaredFields())));
+  public static Map<String, Pair<Field, AwsFieldProperty>> computeFieldProperties(final Class<?> clazz) {
+    return fieldsWithPropertyAnnotationMap.computeIfAbsent(clazz,
+        c1 -> getDeclaredFieldsWithAnnotation(getClassHierarchy(c1).stream().flatMap(c2 -> Stream.of(c2.getDeclaredFields()))));
   }
 
   private static Map<String, Pair<Field, AwsFieldProperty>> getDeclaredFieldsWithAnnotation(final Stream<Field> stream) {
@@ -271,13 +285,17 @@ public final class SerializationUtil {
     }
   }
 
-  public static Object coerceFromString(final String encodedValue, final Class<?> clazz) {
+  public static Object coerceValueFromString(final String encodedValue, final Class<?> clazz) {
     if (String.class.isAssignableFrom(clazz)) {
       return encodedValue;
+    } else if (Long.class.isAssignableFrom(clazz)) {
+      return Long.parseLong(encodedValue);
     } else if (Integer.class.isAssignableFrom(clazz)) {
       return Integer.parseInt(encodedValue);
     } else if (Double.class.isAssignableFrom(clazz)) {
       return Double.parseDouble(encodedValue);
+    } else if (Float.class.isAssignableFrom(clazz)) {
+      return Float.parseFloat(encodedValue);
     } else if (Boolean.class.isAssignableFrom(clazz)) {
       return Boolean.parseBoolean(encodedValue);
     } else {

--- a/generic-messages/src/test/java/com/langtoun/messages/AppTest.java
+++ b/generic-messages/src/test/java/com/langtoun/messages/AppTest.java
@@ -152,9 +152,6 @@ public class AppTest extends TestCase {
           (stop - start) / 1000000L, iters, failures, dataLen);
     });
     System.out.println("---- TIMING STOP (SERIALIZATION - REGULAR) ----");
-  }
-
-  public void testCustomSerializationTimings() {
     System.out.println("---- TIMING START (SERIALIZATION - CUSTOM) ----");
     IntStream.range(0, 3).forEach(loop -> {
       long dataLen = 0;

--- a/generic-messages/src/test/java/com/langtoun/messages/AppTest.java
+++ b/generic-messages/src/test/java/com/langtoun/messages/AppTest.java
@@ -161,9 +161,6 @@ public class AppTest extends TestCase {
           (stop - start) / 1000000L, iters, failures, dataLen);
     });
     System.out.println("---- TIMING STOP (SERIALIZATION - REGULAR) ----");
-  }
-
-  public void testCustomSerializationTimings() {
     System.out.println("---- TIMING START (SERIALIZATION - CUSTOM) ----");
     IntStream.range(0, 3).forEach(loop -> {
       long dataLen = 0;

--- a/generic-messages/src/test/java/com/langtoun/messages/types/gen/cars/CustomComplexCarWithFeatures.java
+++ b/generic-messages/src/test/java/com/langtoun/messages/types/gen/cars/CustomComplexCarWithFeatures.java
@@ -1,0 +1,61 @@
+package com.langtoun.messages.types.gen.cars;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.langtoun.messages.annotations.AwsFieldProperty;
+import com.langtoun.messages.annotations.AwsTypeDefinition;
+import com.langtoun.messages.annotations.CustomTypeEncoding;
+import com.langtoun.messages.annotations.FieldOrder;
+import com.langtoun.messages.generic.AwsComplexTypeJsonDeserializer;
+import com.langtoun.messages.generic.AwsCustomEncodingSerializer;
+import com.langtoun.messages.types.FieldEncodingType;
+
+/**
+ * Surrogate for a generated type that extends {@link ComplexCar}.
+ *
+ */
+@JsonSerialize(using = AwsCustomEncodingSerializer.class, as = CustomComplexCarWithFeatures.class)
+@JsonDeserialize(using = AwsComplexTypeJsonDeserializer.class, as = CustomComplexCarWithFeatures.class)
+//@Format-Off
+@AwsTypeDefinition(
+  fieldOrder = @FieldOrder({
+    "colour", "type", "rightHandDrive", "engine", "features"
+  }),
+  encoding = @CustomTypeEncoding(
+    prefix = "<<<", suffix = ">>>", fieldSep = "|", keyValSep = "="
+  )
+)
+//@Format-On
+public class CustomComplexCarWithFeatures extends CustomComplexCar {
+
+  @AwsFieldProperty(required = true, encoding = FieldEncodingType.BASE64)
+  private final List<CarFeature> features = new ArrayList<>();
+
+  public CustomComplexCarWithFeatures() {
+    // do nothing
+  }
+
+  public CustomComplexCarWithFeatures(final String colour, final String type, final Boolean rightHandDrive,
+      final CarEngine engine) {
+    super(colour, type, rightHandDrive, engine);
+  }
+
+  public List<CarFeature> getFeatures() { return features; }
+
+  public void setFeatures(final List<CarFeature> features) {
+    this.features.addAll(features);
+  }
+
+  public void addFeature(final CarFeature feature) {
+    features.add(feature);
+  }
+
+  @Override
+  public String toString() {
+    return AwsCustomEncodingSerializer.serializeCustomEncoding(this);
+  }
+
+}


### PR DESCRIPTION
This change adds two caches to the SerializationHelper (formerly known
as SerializationUtil):

- a map of Class<?> to field name, Field, and AwsFieldProperty
- a map of Class<?> to boolean result of usesCustomTypeEncoding

The regular deserialization has been changed to iterate over the nodes
that are present rather than the Field objects that might be present
(then searching for the node).

There was also a bug in the custom serializer in the case where it was
called with a String. The instanceof check was being executed after the
serialize method had already determined that it was dealing with a
complex type.